### PR TITLE
NEID Translator Level 3 ensemble and bugfixes

### DIFF
--- a/docs/tutorials/level3datastandard_from_NEIDlevel2_example.ipynb
+++ b/docs/tutorials/level3datastandard_from_NEIDlevel2_example.ipynb
@@ -1,0 +1,200 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ea89b983",
+   "metadata": {},
+   "source": [
+    "# Level 3 Data Standard from NEID Level 2 Spectrum -- Stitched and Flux-Conserved Rebin\n",
+    "\n",
+    "This Jupyter Notebook demonstrates how to create a Level 3 data standard fits file from NEID Level 2 fits file.\n",
+    "\n",
+    "- Loading NEID spectral data from a FITS file and creates a Level 3 object.\n",
+    "- Writes a Level 3 data standard FITS file.\n",
+    "- Reads Level 3 FITS file with `astropy`.\n",
+    "- Displays the primary header.\n",
+    "- Visualization of the stitched spectrum with `matplotlib`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "408e98ed",
+   "metadata": {},
+   "source": [
+    "## Level 3 Data Standard Creation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb2130c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rvdata.instruments.neid.level3 import NEIDRV3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b28ad9c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "l3obj = NEIDRV3.from_fits(\"../../rvdata/neidL2_20241101T053244.fits\",instrument=\"NEID\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af58f530",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "l3obj.to_fits(\"./neid_L3_standard_20241101T053244.fits\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "923c0e2d",
+   "metadata": {},
+   "source": [
+    "## `matplotlib` Visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e90b6e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.dates as mdates\n",
+    "\n",
+    "import matplotlib\n",
+    "matplotlib.pyplot.rcdefaults()\n",
+    "matplotlib.rcParams['font.family'] = 'Arial Narrow'\n",
+    "matplotlib.rcParams['font.size']   = 15\n",
+    "matplotlib.rcParams['axes.linewidth'] = 1.25\n",
+    "\n",
+    "matplotlib.rcParams['xtick.top'] = True\n",
+    "matplotlib.rcParams['ytick.right'] = True\n",
+    "\n",
+    "matplotlib.rcParams['xtick.minor.visible'] = True   # visibility of minor ticks on x-axis\n",
+    "matplotlib.rcParams['ytick.minor.visible'] = True   # visibility of minor ticks on y-axis\n",
+    "\n",
+    "matplotlib.rcParams['xtick.direction'] = 'in'\n",
+    "matplotlib.rcParams['ytick.direction'] = 'in'\n",
+    "\n",
+    "matplotlib.rcParams['xtick.major.size'] = 9.0       # major tick size in points\n",
+    "matplotlib.rcParams['xtick.minor.size'] = 4.0       # minor tick size in points\n",
+    "matplotlib.rcParams['ytick.major.size'] = 9.0       # major tick size in points\n",
+    "matplotlib.rcParams['ytick.minor.size'] = 4.0       # minor tick size in points\n",
+    "\n",
+    "matplotlib.rcParams['xtick.major.width'] = 1.25     # major tick width in points\n",
+    "matplotlib.rcParams['xtick.minor.width'] = 1.0     # minor tick width in points\n",
+    "matplotlib.rcParams['ytick.major.width'] = 1.25     # major tick width in points\n",
+    "matplotlib.rcParams['ytick.minor.width'] = 1.0     # minor tick width in points\n",
+    "\n",
+    "matplotlib.rcParams['date.autoformatter.month'] = '%Y %b'\n",
+    "matplotlib.rcParams['date.autoformatter.day'] = '%Y %b %d'\n",
+    "matplotlib.rcParams['date.autoformatter.hour'] = '%b %d\\n%Hh'\n",
+    "matplotlib.rcParams['date.autoformatter.minute'] = '%b %d\\n%H:%M'\n",
+    "\n",
+    "matplotlib.rcParams['grid.linewidth'] = 1.25\n",
+    "\n",
+    "import ipympl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5a2640f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.io import fits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "502a557d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with fits.open(\"neid_L3_standard_20241101T053244.fits\") as hdul:\n",
+    "    hdul.info()\n",
+    "    l3prihdr = hdul[\"PRIMARY\"].header\n",
+    "    st_wave = hdul[\"STITCHED_CORR_TRACE1_WAVE\"].data\n",
+    "    st_flux = hdul[\"STITCHED_CORR_TRACE1_FLUX\"].data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f6a32be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "l3prihdr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb162416",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f, ax = plt.subplots(1,1,figsize=(11,5))\n",
+    "ax.step(st_wave,st_flux, where='mid', c='k', lw=0.1)\n",
+    "\n",
+    "\n",
+    "ax.set_xlabel('Wavelength [A]')\n",
+    "ax.set_ylabel('Flux [e$^{-}$]')\n",
+    "ax.set_title('Tau Ceti Stitched Spectrum (Flux-Conserving Rebin)',loc='left',color='black',fontsize=15)\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8817aba7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3665232b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py313",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rvdata/core/models/base.py
+++ b/rvdata/core/models/base.py
@@ -129,8 +129,8 @@ class RVDataModel(object):
                 if isinstance(hdu, fits.PrimaryHDU):
                     self.headers[hdu.name] = hdu.header
                 elif isinstance(hdu, fits.BinTableHDU):
-                    t = Table.read(hdu)
                     if "RECEIPT" in hdu.name:
+                        t = Table.read(hdu)
                         # Table contains the RECEIPT
                         df: pd.DataFrame = t.to_pandas()
                         # TODO: get receipt columns from core.models.config.BASE-RECEIPT-columns.csv

--- a/rvdata/core/models/base.py
+++ b/rvdata/core/models/base.py
@@ -159,7 +159,7 @@ class RVDataModel(object):
                 elif lvl == 3:
                     import rvdata.core.models.level3
 
-                    method = rvdata.core.models.level4.RV3._read
+                    method = rvdata.core.models.level3.RV3._read
                     method(self, hdu_list)
                 elif lvl == 4:
                     import rvdata.core.models.level4

--- a/rvdata/core/models/base.py
+++ b/rvdata/core/models/base.py
@@ -204,9 +204,11 @@ class RVDataModel(object):
                     elif row["Data type"].lower() == "double":
                         self.headers["PRIMARY"][key] = np.float64(value)
                     elif row["Data type"].lower() == "boolean":
-                        self.headers['PRIMARY'][key] = bool(value)
+                        self.headers["PRIMARY"][key] = bool(value)
                     else:
-                        warnings.warn(f"Unknown type {row['Data type']} for keyword {key}")
+                        warnings.warn(
+                            f"Unknown type {row['Data type']} for keyword {key}"
+                        )
                 except (TypeError, AttributeError, ValueError):
                     warnings.warn(
                         f"Cannot convert value {value} for keyword {key} to type {row['Data type']}"

--- a/rvdata/core/models/config/L2-PRIMARY-keywords.csv
+++ b/rvdata/core/models/config/L2-PRIMARY-keywords.csv
@@ -1,19 +1,19 @@
 ﻿Keyword,Description,Units,Data type,Example Value,Default,Required,Comments
 INSTRUME,Instrument name,N/A,String,"NEID or HARPS",UNKNOWN,Y,
 ORGANIZA,"Organization the data belongs to, for licensing purposes",N/A,String,"ESO or CC-0",CC-0,N,
-ORIGIN,Entity that created this file,N/A,String,"ESO or NOIRLab",'',N,
+ORIGIN,Entity that created this file,N/A,String,"ESO or NOIRLab",,N,
 DATALVL,Data Product Base Level,N/A,String,"L2 or L3",UNKNOWN,Y,
 OBSERVER,Observer,N/A,String,"Bender",UNKNOWN,Y,
-PROGRAM,Observing program name,N/A,String,"Bender01",UNKNOWN,N*,"For data filtering and attribution; default to 'Unknown' if it doesn't exist"
-PINAME,Program PI Name,N/A,String,"Bender",UNKNOWN,N*,"For data filtering and attribution; default to 'Unknown' if it doesn't exist"
+PROGRAM,Observing program name,N/A,String,"Bender01",UNKNOWN,N*,"For data filtering and attribution; default to Unknown if it doesnt exist"
+PINAME,Program PI Name,N/A,String,"Bender",UNKNOWN,N*,"For data filtering and attribution; default to Unknown if it doesnt exist"
 OBSTYPE,Observation type,N/A,String,"Sci or Eng",UNKNOWN,Y,
-OBSMODE,Observing mode,N/A,String,"HR or HE",'',N,
-READMODE,Readout Mode,N/A,String,"Fast; Slow; UTR; FowlerN; or CDS",'',N,
+OBSMODE,Observing mode,N/A,String,"HR or HE",,N,
+READMODE,Readout Mode,N/A,String,"Fast; Slow; UTR; FowlerN; or CDS",,N,
 BINNING,Binning Mode,N/A,String,"1x1 or 2x2",UNKNOWN,Y,
 NUMTRACE,Iterator for Number of Object related keywords,N/A,UInt,1,UNDEFINED,Y,
 NUMORDER,Number of Orders,N/A,Uint,172,UNDEFINED,Y,
 OBJECT,Primary Object Name,N/A,String,"HD 10700",UNKNOWN,Y,"For multi-object observing this corresponds to center of field object"
-ALIASES,"user defined name(s) for the object, ; separated",N/A,String,"Tau Ceti; My Favorite Star",'',N,
+ALIASES,"user defined name(s) for the object, ; separated",N/A,String,"Tau Ceti; My Favorite Star",,N,
 FILENAME,Name of the FITS file,N/A,String,"InstL#_YYYYMMDDThhmmss.fits",UNKNOWN,Y,
 DATE,Last modification date/time of this file,UTC,String,"2018-04-26T15:53:13.456",UNKNOWN,Y,
 DATE-OBS,Date/time at start of exposure,UTC,String,"2018-04-26T15:53:13.456",UNKNOWN,Y,
@@ -28,66 +28,66 @@ CDEC1 ... CDEC#,Catalog declination for object in trace 1 to #,sexagesimal,Strin
 CEQNX1 ... CEQNX#,Catalog equinox for object in trace 1 to #,yr,Float,2000,UNDEFINED,Y,"Can be expanded to multiple keywords indexed 1 to #"
 CEPCH1 ... CEPCH#,Catalog epoch for object in trace 1 to #,yr,Float,2015.5,UNDEFINED,Y,"Can be expanded to multiple keywords indexed 1 to #"
 CRV1 ... CRV#,Catalog Systemic RV for for object in trace 1 to #,km/s,Float,45.654,UNDEFINED,Y,"Can be expanded to multiple keywords indexed 1 to #"
-CPLX1 ... CPLX#,Catalog parallax for object in trace 1 to #,mas,Float,20.45,'',N,"Can be expanded to multiple keywords indexed 1 to #"
-CPMR1 ... CPMR#,Catalog proper motion RA for object in trace 1 to #,�/yr,Float,0.0345,'',N,"Can be expanded to multiple keywords indexed 1 to #"
-CPMD1 ... CPMD#,Catalog proper motion DEC for object in trace 1 to #,�/yr,Float,0.345,'',N,"Can be expanded to multiple keywords indexed 1 to #"
-CZ1 ... CZ#,Catalog Z for for object in trace 1 to #,N/A,Float,0.00000454,'',N,"Can be expanded to multiple keywords indexed 1 to #"
-CCLRN1 ... CCLRN#,Catalog color 1 - color 2 name for object in trace 1 to #,N/A,String,"Gaia B-R",'',N,"Can be expanded to multiple keywords indexed 1 to #"
-CCLR1 ... CCLR#,Catalog color 1 - color 2 for object in trace 1 to #,mag,Float,0.47,'',N,"Can be expanded to multiple keywords indexed 1 to #"
+CPLX1 ... CPLX#,Catalog parallax for object in trace 1 to #,mas,Float,20.45,,N,"Can be expanded to multiple keywords indexed 1 to #"
+CPMR1 ... CPMR#,Catalog proper motion RA for object in trace 1 to #,�/yr,Float,0.0345,,N,"Can be expanded to multiple keywords indexed 1 to #"
+CPMD1 ... CPMD#,Catalog proper motion DEC for object in trace 1 to #,�/yr,Float,0.345,,N,"Can be expanded to multiple keywords indexed 1 to #"
+CZ1 ... CZ#,Catalog Z for for object in trace 1 to #,N/A,Float,0.00000454,,N,"Can be expanded to multiple keywords indexed 1 to #"
+CCLRN1 ... CCLRN#,Catalog color 1 - color 2 name for object in trace 1 to #,N/A,String,"Gaia B-R",,N,"Can be expanded to multiple keywords indexed 1 to #"
+CCLR1 ... CCLR#,Catalog color 1 - color 2 for object in trace 1 to #,mag,Float,0.47,,N,"Can be expanded to multiple keywords indexed 1 to #"
 OBSERVAT,Observatory name,N/A,String,KPNO,UNKNOWN,Y,
-TELESCOP,Telescope name,N/A,String,"ESO-VLT-U1234" "WIYN" or "NEIDSOLARFEED",UNKNOWN,Y,For solar observations - if solarfeed has its own name use that otherwise use an instrument + solarfeed type entry
+TELESCOP,Telescope name,N/A,String,"ESO-VLT-U1234 WIYN or NEIDSOLARFEED",UNKNOWN,Y,"For solar observations - if solarfeed has its own name use that otherwise use an instrument + solarfeed type entry"
 NUMTEL,Number of telescopes used in the observation,N/A,UInt,1,UNDEFINED,Y,
 TELEID1 ... TELEID#,Labels for telescopes as indexed in TCS keywords,N/A,String,"ESO-VLT-U1",UNKNOWN,Y,		
 GEOSYS,Coordinate system for observatory / telesccope location,N/A,String,"GRS80",UNKNOWN,Y,																																																					
 OBSLON,Longitude used for barycentric correction,deg,Float,-111.600562,UNDEFINED,Y,Recommend 6 decimal places which is ~1m accuracy
 OBSLAT,Latitude used for barycentric correction,deg,Float,31.958092,UNDEFINED,Y,Recommend 6 decimal places which is ~1m accuracy
 OBSALT,Altitude used for barycentric correction,meters,Float,2091,UNDEFINED,Y,Recommend 6 decimal places which is ~1m accuracy
-OBSGEO-X,Cartesian Coordinate X used for barycentric correction,meters,Float,5327395.964,'',N,geocentric Cartesian triple incarnation of the traditional lat/lon/alt position on earth
-OBSGEO-Y,Cartesian Coordinate Y used for barycentric correction,meters,Float,-1719170.488,'',N,geocentric Cartesian triple incarnation of the traditional lat/lon/alt position on earth
-OBSGEO-Z,Cartesian Coordinate Z used for barycentric correction,meters,Float,3051490.766,'',N,geocentric Cartesian triple incarnation of the traditional lat/lon/alt position on earth
+OBSGEO-X,Cartesian Coordinate X used for barycentric correction,meters,Float,5327395.964,,N,geocentric Cartesian triple incarnation of the traditional lat/lon/alt position on earth
+OBSGEO-Y,Cartesian Coordinate Y used for barycentric correction,meters,Float,-1719170.488,,N,geocentric Cartesian triple incarnation of the traditional lat/lon/alt position on earth
+OBSGEO-Z,Cartesian Coordinate Z used for barycentric correction,meters,Float,3051490.766,,N,geocentric Cartesian triple incarnation of the traditional lat/lon/alt position on earth
 ISSOLAR,Boolean to indicate if observation is of the sun,N/A,Boolean,FALSE,UNKNOWN,Y,
-SEEING,Seeing at beginning of exposure,arcsec,Float,1.2,'',N,
-AIRMASS,Airmass at center field at beginning of exposure,secZ,Float,1.3,'',N,
-TTIME,TCS-data date/time,UTC,String,"2018-04-26T15:53:13",'',N,
-TEQNX,TCS equinox,yr,String,"J2000",'',N,
-TEPCH,TCS epoch,yr,String,"J2000",'',N,
-TLST1 ... TLST#,TCS local sidereal time for telescope 1 to #,sexagesimal,String,"14:23:43",'',N,"Can be expanded to multiple keywords indexed 1 to #"
-TRA1 ... TRA#,TCS RA for telescope 1 to #,sexagesimal,String,"13:43:42.3456",'',N,"Can be expanded to multiple keywords indexed 1 to #"
-TDEC1 ... TDEC#,TCS DEC for telescope 1 to #,sexagesimal,String,"-13:34:12.7787",'',N,"Can be expanded to multiple keywords indexed 1 to #"
-TEL1 ... TEL#,TCS elevation angle for telescope 1 to #,deg,Float,43.5,'',N,"Can be expanded to multiple keywords indexed 1 to #"
-TZA1 ... TZA#,TCS zenith angle for telescope 1 to #,deg,Float,35.5435,'',N,"Can be expanded to multiple keywords indexed 1 to #"
-TAZ1 ... TAZ#,TCS azimuth angle for telescope 1 to #,deg,Float,124.3,'',N,"Can be expanded to multiple keywords indexed 1 to #"
-THA1 ... THA#,TCS hour angle for telescope 1 to #,sexagesimal,String,"-2:34:43.3455",'',N,"Can be expanded to multiple keywords indexed 1 to #"
-PARST1 ... PARST#,Parallactic angle at exposure start for telescope 1 to #,deg,Float,175.2,'',N,"Can be expanded to multiple keywords indexed 1 to #"
-PAREND1 ... PAREND#,Parallactic angle at exposure end for telescope 1 to #,deg,Float,180.7,'',N,"Can be expanded to multiple keywords indexed 1 to #"
-ROTANG,Rotator angle,deg,Float,80.3,'',N,
-SUNEL,Sun Elevation Angle,deg,Float,-18.5,'',N,
-MOONANG,Target-Moon Angle,deg,Float,34.56,'',N,
-MOONEL,Moon Elevation Angle,deg,Float,26.8,'',N,
-MOONILLU,Moon illumination,%,Float,23.4,'',N,
-MOONRV,RV of reflected sunlight off moon,km/s,Float,1.3,'',N,
-INHUM,relative humidity inside dome,%,Float,56.6,'',N,
-INHUMT,INHUM timestamp,UTC,String,"2024-02-20T03:31:33",'',N,
-OUTTMP,Outside temperature,deg C,Float,"0.0",'',N,
-OUTTMPT,OUTTMP timestamp,UTC,String,"2024-02-20T03:31:33",'',N,
-OUTHUM,Outside relative humidity,%,Float,56.6,'',N,
-OUTHUMT,OUTHUM timestamp,UTC,String,"2024-02-20T03:31:33",'',N,
-ENVWINDS,Wind speed,m/s,Float,23.4,'',N,"Details are obs specific and not uniform; best effort as available from the observatory"
-ENVWINDD,Wind direction,angle,Float,133.5,'',N,"Details on where wind is measured (position of weather station) should be captured in documentation"
+SEEING,Seeing at beginning of exposure,arcsec,Float,1.2,,N,
+AIRMASS,Airmass at center field at beginning of exposure,secZ,Float,1.3,,N,
+TTIME,TCS-data date/time,UTC,String,"2018-04-26T15:53:13",,N,
+TEQNX,TCS equinox,yr,String,"J2000",,N,
+TEPCH,TCS epoch,yr,String,"J2000",,N,
+TLST1 ... TLST#,TCS local sidereal time for telescope 1 to #,sexagesimal,String,"14:23:43",,N,"Can be expanded to multiple keywords indexed 1 to #"
+TRA1 ... TRA#,TCS RA for telescope 1 to #,sexagesimal,String,"13:43:42.3456",,N,"Can be expanded to multiple keywords indexed 1 to #"
+TDEC1 ... TDEC#,TCS DEC for telescope 1 to #,sexagesimal,String,"-13:34:12.7787",,N,"Can be expanded to multiple keywords indexed 1 to #"
+TEL1 ... TEL#,TCS elevation angle for telescope 1 to #,deg,Float,43.5,,N,"Can be expanded to multiple keywords indexed 1 to #"
+TZA1 ... TZA#,TCS zenith angle for telescope 1 to #,deg,Float,35.5435,,N,"Can be expanded to multiple keywords indexed 1 to #"
+TAZ1 ... TAZ#,TCS azimuth angle for telescope 1 to #,deg,Float,124.3,,N,"Can be expanded to multiple keywords indexed 1 to #"
+THA1 ... THA#,TCS hour angle for telescope 1 to #,sexagesimal,String,"-2:34:43.3455",,N,"Can be expanded to multiple keywords indexed 1 to #"
+PARST1 ... PARST#,Parallactic angle at exposure start for telescope 1 to #,deg,Float,175.2,,N,"Can be expanded to multiple keywords indexed 1 to #"
+PAREND1 ... PAREND#,Parallactic angle at exposure end for telescope 1 to #,deg,Float,180.7,,N,"Can be expanded to multiple keywords indexed 1 to #"
+ROTANG,Rotator angle,deg,Float,80.3,,N,
+SUNEL,Sun Elevation Angle,deg,Float,-18.5,,N,
+MOONANG,Target-Moon Angle,deg,Float,34.56,,N,
+MOONEL,Moon Elevation Angle,deg,Float,26.8,,N,
+MOONILLU,Moon illumination,%,Float,23.4,,N,
+MOONRV,RV of reflected sunlight off moon,km/s,Float,1.3,,N,
+INHUM,relative humidity inside dome,%,Float,56.6,,N,
+INHUMT,INHUM timestamp,UTC,String,"2024-02-20T03:31:33",,N,
+OUTTMP,Outside temperature,deg C,Float,"0.0",,N,
+OUTTMPT,OUTTMP timestamp,UTC,String,"2024-02-20T03:31:33",,N,
+OUTHUM,Outside relative humidity,%,Float,56.6,,N,
+OUTHUMT,OUTHUM timestamp,UTC,String,"2024-02-20T03:31:33",,N,
+ENVWINDS,Wind speed,m/s,Float,23.4,,N,"Details are obs specific and not uniform; best effort as available from the observatory"
+ENVWINDD,Wind direction,angle,Float,133.5,,N,"Details on where wind is measured (position of weather station) should be captured in documentation"
 DRPTAG,RV DRP version,N/A,String,"v1.1.0",UNKNOWN,Y,
 EPRVTAG,Version of EPRV standard applied,N/A,String,"v1.1.0",UNKNOWN,Y,
 VOCLASS,Version of EPRV standard applied,N/A,String,"EPRVSTANDARDv1.1.0",UNKNOWN,Y,
-DRPHASH,Git commit hash,N/A,String,"a1b2c3d4e5f67890abcdef1234567890abcdef12",'',N,
+DRPHASH,Git commit hash,N/A,String,"a1b2c3d4e5f67890abcdef1234567890abcdef12",,N,
 INSTERA,Tag to track permanent changes to instrument,N/A,String,"v2.3.0",UNKNOWN,Y,
-EXTRACT,Type of 1D extraction,N/A,String,"sum or flatrelative or optimal",'',N,
-EXSNR1 ... EXSNR#,Extracted signal-to-noise at EXSNRW1 to EXSNRW#,SNR/1-D pixel,FLOAT,245.35,'',N,"Can be expanded to multiple keywords indexed 1 to #; Meant to be a set of useful SNR checks, not one for every order"
-EXSNRW1 ... EXSNRW#,Wavelength at which EXTSNR1 to EXTSNR# is measured,Angstroms,FLOAT,5530,'',N,"Can be expanded to multiple keywords indexed 1 to #; Meant to be a set of useful SNR checks, not one for every order"
+EXTRACT,Type of 1D extraction,N/A,String,"sum or flatrelative or optimal",,N,
+EXSNR1 ... EXSNR#,Extracted signal-to-noise at EXSNRW1 to EXSNRW#,SNR/1-D pixel,FLOAT,245.35,,N,"Can be expanded to multiple keywords indexed 1 to #; Meant to be a set of useful SNR checks, not one for every order"
+EXSNRW1 ... EXSNRW#,Wavelength at which EXTSNR1 to EXTSNR# is measured,Angstroms,FLOAT,5530,,N,"Can be expanded to multiple keywords indexed 1 to #; Meant to be a set of useful SNR checks, not one for every order"
 FULLCOMP,Is this file fully compliant with the RVSTAND EPRV standard?,N/A,String,"Yes or No",UNKNOWN,Y,
-TELFLAG,Issues with observatory or telescope?,N/A,String,"Pass or Fail or Warn","PASS",N,"Default to 'Pass'. If 'Fail' or 'Warn' then more detail should be provided via the bitfields"
-INSTFLAG,Issues with instrument?,N/A,String,"Pass or Fail or Warn","PASS",N,"Default to 'Pass'. If 'Fail' or 'Warn' then more detail should be provided via the bitfieldsx"
-DRPFLAG,Issues with pipeline?,N/A,String,"Pass or Fail or Warn",'"PASS",N,"Default to 'Pass'. If 'Fail' or 'Warn' then more detail should be provided via the bitfields"
-ADDFLAG,Additional team defined flag,N/A,String,"Pass or Fail or Warn",'',N,"Note what this corresponds to in documentation"
-OBSFLAG,Observer pass/fail for exposure,N/A,String,"Pass or Fail",'',N,
+TELFLAG,Issues with observatory or telescope?,N/A,String,"Pass or Fail or Warn","PASS",N,"Default to Pass. If Fail or Warn then more detail should be provided via the bitfields"
+INSTFLAG,Issues with instrument?,N/A,String,"Pass or Fail or Warn","PASS",N,"Default to Pass. If Fail or Warn then more detail should be provided via the bitfieldsx"
+DRPFLAG,Issues with pipeline?,N/A,String,"Pass or Fail or Warn","PASS",N,"Default to Pass. If Fail or Warn then more detail should be provided via the bitfields"
+ADDFLAG,Additional team defined flag,N/A,String,"Pass or Fail or Warn",,N,"Note what this corresponds to in documentation"
+OBSFLAG,Observer pass/fail for exposure,N/A,String,"Pass or Fail",,N,
 SUMMFLAG,Summary roll up of other flag keywords,N/A,String,"Pass or Fail",UNKNOWN,Y,
 DQLVL0,Quality check bitfield of N characters,N/A,UInt,0,UNDEFINED,Y,"see e.g. https://neid.ipac.caltech.edu/docs/NEID-DRP/bitfields.html"
 DQLVL1,Quality check bitfield of N characters,N/A,UInt,0,UNDEFINED,Y,"see e.g. https://neid.ipac.caltech.edu/docs/NEID-DRP/bitfields.html"

--- a/rvdata/core/models/config/L3-PRIMARY-keywords.csv
+++ b/rvdata/core/models/config/L3-PRIMARY-keywords.csv
@@ -2,6 +2,6 @@ Keyword,Description,Units,Data type,Example Value,FITS required,Default,Inherite
 BLZCORR,Has stellar SED been removed?,N/A,Boolean,True,N,False,N,Y,default is to do this in L3
 LMPCORR,Has lamp SED been removed?,N/A,Boolean,False,N,False,N,Y,default is NOT to do this in L3
 SEDCORR,Has stellar SED been removed?,N/A,Boolean,False,N,False,N,Y,default is NOT to do this in L3
-INTERPMD,interpolation method used to resample input spectrum onto the velocity scale,N/A,String,BINDENSITY,,UNDEFINED,,,default is to use bindensity code from JB Delisle
-FLXNRMMD,flux normalization method,N/A,String,None,,UNDEFINED,,,default is None but include so that other extensions can populate
-DISPCORR,Has wavelength dispersion been corrected?,N/A,Boolean,True,,UNDEFINED,,,default is to correct dispersion
+INTERPMD,interpolation method used to resample input spectrum onto the velocity scale,N/A,String,BINDENSITY,N,UNDEFINED,N,Y,default is to use bindensity code from JB Delisle
+FLXNRMMD,flux normalization method,N/A,String,None,N,UNDEFINED,N,Y,default is None but include so that other extensions can populate
+DISPCORR,Has wavelength dispersion been corrected?,N/A,Boolean,True,N,False,N,Y,default is to correct dispersion

--- a/rvdata/core/models/config/L3-PRIMARY-keywords.csv
+++ b/rvdata/core/models/config/L3-PRIMARY-keywords.csv
@@ -1,7 +1,7 @@
 Keyword,Description,Units,Data type,Example Value,FITS required,Default,Inherited? [Y/N/M],Required,Notes
-BLZCORR,Has stellar SED been removed?,N/A,Boolean,TRUE,N,,N,Y,default is to do this in L3
-LMPCORR,Has lamp SED been removed?,N/A,Boolean,FALSE,N,,N,Y,default is NOT to do this in L3
-SEDCORR,Has stellar SED been removed?,N/A,Boolean,FALSE,N,,N,Y,default is NOT to do this in L3
-INTERPMD,interpolation method used to resample input spectrum onto the velocity scale,N/A,String,BINDENSITY,,,,,default is to use bindensity code from JB Delisle
-FLXNRMMD,flux normalization method,N/A,String,None,,,,,default is None but include so that other extensions can populate"
-DISPCORR,Has wavelength dispersion been corrected?,N/A,Boolean,TRUE,,,,,default is to correct dispersion
+BLZCORR,Has stellar SED been removed?,N/A,Boolean,True,N,False,N,Y,default is to do this in L3
+LMPCORR,Has lamp SED been removed?,N/A,Boolean,False,N,False,N,Y,default is NOT to do this in L3
+SEDCORR,Has stellar SED been removed?,N/A,Boolean,False,N,False,N,Y,default is NOT to do this in L3
+INTERPMD,interpolation method used to resample input spectrum onto the velocity scale,N/A,String,BINDENSITY,,UNDEFINED,,,default is to use bindensity code from JB Delisle
+FLXNRMMD,flux normalization method,N/A,String,None,,UNDEFINED,,,default is None but include so that other extensions can populate
+DISPCORR,Has wavelength dispersion been corrected?,N/A,Boolean,True,,UNDEFINED,,,default is to correct dispersion

--- a/rvdata/core/models/config/L3-extensions.csv
+++ b/rvdata/core/models/config/L3-extensions.csv
@@ -3,13 +3,13 @@ HDU,Name,DataType,MinBitDepth,Multiplicity,Required,Description,Comments
 1,INSTRUMENT_HEADER,ImageHDU,,False,True,Inherited instrument header (no data),Carried forward from L2 FITS file
 2,RECEIPT,BinTableHDU,,False,True,Table of operations that have been performed on this file,
 3,DRP_CONFIG,BinTableHDU,,False,True,Pipeline details (settings etc) to go from native data to L2,
-4,ORDER_TABLE,BinTableHDU,,TRUE,TRUE,Table capturing the wavelength extent of each order, Required columns: physical echelle order; index echelle order; start wavelength [64bit]; end wavelength [64bit]
-5,STITCHED_CORR_TRACE1_FLUX,ImageHDU,,True,False,Order stitched blaze-corrected flux in trace 1,This flux array stitches together all orders and has been blaze corrected
-6,STITCHED_CORR_TRACE1_WAVE,ImageHDU,64,True,False,Order stitched BC- and drift-corrected wavelength solution for trace 1,This wavelength solution stitches together all orders adn has been both drift and barycentric corrected
-7,STITCHED_CORR_TRACE1_VAR,ImageHDU,,True,False,Order stitched variance for the flux in STITCHED_CORR_TRACE1_FLUX,This variance array stitches together all orders and is based on the blaze corrected flux (STITCHED_CORR_TRACE1_FLUX)
-8,COMBINED_STITCHED_CORR_FLUX,ImageHDU,,True,True,Order stitched and blaze-corrected flux co-added across all traces,This flux array stitches together all orders and co-adds all traces and has been blaze corrected
-9,COMBINED_STITCHED_CORR_WAVE,ImageHDU,64,True,True,Order stitched BC- and drift-corrected wavelength solution,This wavelength solution stitches together all orders and has been both drift and barycentric corrected
-10,COMBINED_STITCHED_CORR_VAR,ImageHDU,,True,True,Order stitched variance for the combined flux in COMBINED_STITCHED_CORR_FLUX,This variance array stitches together all orders and is based on the co-added and blaze corrected flux (STITCHED_COMBINED_CORR_FLUX)
+4,ORDER_TABLE,BinTableHDU,,False,True,Table capturing the wavelength extent of each order, Required columns: physical echelle order; index echelle order; start wavelength [64bit]; end wavelength [64bit]
+5,STITCHED_CORR_TRACE1_FLUX,ImageHDU,,True,True,Order stitched blaze-corrected flux in trace 1,This flux array stitches together all orders and has been blaze corrected
+6,STITCHED_CORR_TRACE1_WAVE,ImageHDU,64,True,True,Order stitched BC- and drift-corrected wavelength solution for trace 1,This wavelength solution stitches together all orders adn has been both drift and barycentric corrected
+7,STITCHED_CORR_TRACE1_VAR,ImageHDU,,True,True,Order stitched variance for the flux in STITCHED_CORR_TRACE1_FLUX,This variance array stitches together all orders and is based on the blaze corrected flux (STITCHED_CORR_TRACE1_FLUX)
+8,COMBINED_STITCHED_CORR_FLUX,ImageHDU,,False,False,Order stitched and blaze-corrected flux co-added across all traces,This flux array stitches together all orders and co-adds all traces and has been blaze corrected
+9,COMBINED_STITCHED_CORR_WAVE,ImageHDU,64,False,False,Order stitched BC- and drift-corrected wavelength solution,This wavelength solution stitches together all orders and has been both drift and barycentric corrected
+10,COMBINED_STITCHED_CORR_VAR,ImageHDU,,False,False,Order stitched variance for the combined flux in COMBINED_STITCHED_CORR_FLUX,This variance array stitches together all orders and is based on the co-added and blaze corrected flux (STITCHED_COMBINED_CORR_FLUX)
 11,STITCHED_CUSTOMCORR1_TRACE1_FLUX,ImageHDU,,True,False,Additional corrections made to STITCHED_CORR_TRACE1_FLUX,This could include additional corrections such as telluric or sky corrections
 12,STITCHED_CUSTOMCORR1_TRACE1_WAVE,ImageHDU,,True,False,Wavelength solution corresponding to STITCHED_CUSTOMCORR1_TRACE1_FLUX,Wavelength solution corresponding to the flux array in STITCHED_CUSTOMCORR1_TRACE1_FLUX
 13,STITCHED_CUSTOMCORR1_TRACE1_VAR,ImageHDU,,True,False,Variance corresponding to STITCHED_CUSTOMCORR1_TRACE1_FLUX,Variance of the CUSTOMCORR1_TRACE1_FLUX flux array

--- a/rvdata/core/models/config/L3-extensions.csv
+++ b/rvdata/core/models/config/L3-extensions.csv
@@ -1,8 +1,8 @@
 HDU,Name,DataType,MinBitDepth,Multiplicity,Required,Description,Comments
 0,PRIMARY,PrimaryHDU,,False,True,EPRV Standard FITS HEADER (no data),Carried forward from L2 FITS file
 1,INSTRUMENT_HEADER,ImageHDU,,False,True,Inherited instrument header (no data),Carried forward from L2 FITS file
-2,RECEIPT,BinTableHDU,,False,True,Table of operations that have been performed on this file
-3,DRP_CONFIG,BinTableHDU,,False,True,Pipeline details (settings etc) to go from native data to L2
+2,RECEIPT,BinTableHDU,,False,True,Table of operations that have been performed on this file,
+3,DRP_CONFIG,BinTableHDU,,False,True,Pipeline details (settings etc) to go from native data to L2,
 4,ORDER_TABLE,BinTableHDU,,TRUE,TRUE,Table capturing the wavelength extent of each order, Required columns: physical echelle order; index echelle order; start wavelength [64bit]; end wavelength [64bit]
 5,STITCHED_CORR_TRACE1_FLUX,ImageHDU,,True,False,Order stitched blaze-corrected flux in trace 1,This flux array stitches together all orders and has been blaze corrected
 6,STITCHED_CORR_TRACE1_WAVE,ImageHDU,64,True,False,Order stitched BC- and drift-corrected wavelength solution for trace 1,This wavelength solution stitches together all orders adn has been both drift and barycentric corrected

--- a/rvdata/core/tools/stitch_spectrum.py
+++ b/rvdata/core/tools/stitch_spectrum.py
@@ -1,6 +1,6 @@
 import numpy as np
 from astropy import units as u
-from specutils import Spectrum1D
+from specutils import Spectrum
 from specutils.manipulation import FluxConservingResampler
 from scipy.interpolate import interp1d
 
@@ -133,7 +133,7 @@ def resample_flux_conserving(sci_wav, sci_dflx, spec_mask, nbins):
         wave = sci_wav[iorder, :] * u.AA
         flux = sci_dflx[iorder, :] * u.Unit("adu")  # or the correct unit
         mask = spec_mask[iorder, :]  # boolean mask for NaNs or bad pixels
-        orders.append(Spectrum1D(spectral_axis=wave, flux=flux, mask=mask))
+        orders.append(Spectrum(spectral_axis=wave, flux=flux, mask=mask))
 
     # Define a common output grid
 

--- a/rvdata/core/tools/stitch_spectrum.py
+++ b/rvdata/core/tools/stitch_spectrum.py
@@ -191,10 +191,11 @@ def stitch_orders(
     # instrument configuration parameters
     stitch_config = {
         "NEID": {
-            "iordermin": 4,  # First order to include in stitching
-            "iorderflatbreak": 78,  # Order where the flat breaks
-            "iordermax": 116,  # Last order to include in stitching
+            "iordermin": 4,  # First order to include in stitching # TODO use wav limits instead
+            "iorderflatbreak": 78,  # Order where the flat breaks # TODO make function for flat break
+            "iordermax": 116,  # Last order to include in stitching # TODO use wav limits instead
             "nbins": 50000,  # Number of bins for the stitched spectrum
+            # TODO Specify wavstart and waveend and derive nbins from the input data itself
         }
     }
     inst_stitch_config = stitch_config[inst_stitch_config_sel]

--- a/rvdata/instruments/neid/level2.py
+++ b/rvdata/instruments/neid/level2.py
@@ -5,7 +5,6 @@ import os
 from astropy.io import fits
 import numpy as np
 import pandas as pd
-import pdb
 
 # import base class
 from rvdata.core.models.level2 import RV2

--- a/rvdata/instruments/neid/level3.py
+++ b/rvdata/instruments/neid/level3.py
@@ -110,8 +110,8 @@ class NEIDRV3(RV3):
             phead["BLZCORR"] = True
             phead["LMPCORR"] = True
             phead["SEDCORR"] = False
-            phead["INTERPMD"] = 'BINDENSITY'
-            phead["FLXNRMMD"] = 'None'
+            phead["INTERPMD"] = "BINDENSITY"
+            phead["FLXNRMMD"] = "None"
             phead["DISPCORR"] = True
             self.set_header("PRIMARY", phead)
 
@@ -121,11 +121,10 @@ class NEIDRV3(RV3):
             phead["BLZCORR"] = False
             phead["LMPCORR"] = False
             phead["SEDCORR"] = False
-            phead["INTERPMD"] = 'None'
-            phead["FLXNRMMD"] = 'None'
+            phead["INTERPMD"] = "None"
+            phead["FLXNRMMD"] = "None"
             phead["DISPCORR"] = False
             self.set_header("PRIMARY", phead)
-        
 
         # self.set_header("DRP_CONFIG", OrderedDict(hdul2["CONFIG"].header))
         # self.set_data("DRP_CONFIG", Table(hdul2["CONFIG"].data).to_pandas())

--- a/rvdata/instruments/neid/level3.py
+++ b/rvdata/instruments/neid/level3.py
@@ -1,7 +1,7 @@
 from astropy.io import fits
 
 # from astropy.table import Table
-# import numpy as np
+import numpy as np
 import pandas as pd
 import os
 
@@ -11,6 +11,7 @@ import os
 from rvdata.core.models.level3 import RV3
 
 # from rvdata.core.models.definitions import LEVEL3_EXTENSIONS
+from rvdata.core.models.definitions import LEVEL3_PRIMARY_KEYWORDS
 from rvdata.core.tools import stitch_spectrum
 
 # NEID specific utility functions
@@ -65,6 +66,27 @@ class NEIDRV3(RV3):
         phead["DATALVL"] = 3
 
         # Add L3 specific entries to the primary header
+
+        for i, row in LEVEL3_PRIMARY_KEYWORDS.iterrows():
+            key = row["Keyword"]
+            value = row["Default"]
+            try:
+                if row["Data type"].lower() == "uint":
+                    phead[key] = int(value)
+                elif row["Data type"].lower() == "float":
+                    phead[key] = float(value)
+                elif row["Data type"].lower() == "string":
+                    phead[key] = str(value)
+                elif row["Data type"].lower() == "double":
+                    phead[key] = np.float64(value)
+                elif row["Data type"].lower() == "boolean":
+                    phead[key] = eval(value.capitalize())
+                else:
+                    print(f"Unknown type {row['Data type']} for keyword {key}")
+            except (TypeError, AttributeError, ValueError):
+                print(
+                    f"Cannot convert value {value} for keyword {key} to type {row['Data type']}"
+                )
 
         self.set_header("PRIMARY", phead)
 

--- a/rvdata/instruments/neid/level3.py
+++ b/rvdata/instruments/neid/level3.py
@@ -93,6 +93,7 @@ class NEIDRV3(RV3):
         # Instrument header
         self.set_header("INSTRUMENT_HEADER", hdul2["PRIMARY"].header)
 
+        # TODO iterate over traces
         # read the wavelength, flux, and blaze data
         sci_flx = hdul2["SCIFLUX"].data  # 4-116 order in NEID out of 122
         sci_wav = hdul2["SCIWAVE"].data

--- a/rvdata/instruments/neid/level3.py
+++ b/rvdata/instruments/neid/level3.py
@@ -99,13 +99,32 @@ class NEIDRV3(RV3):
         sci_blz = hdul2["SCIBLAZE"].data
 
         # stitch the orders
-        st_wave, st_flux = stitch_spectrum.stitch_orders(
-            sci_wav, sci_flx, sci_blz, inst_stitch_config_sel="NEID"
-        )
+        try:
+            st_wave, st_flux = stitch_spectrum.stitch_orders(
+                sci_wav, sci_flx, sci_blz, inst_stitch_config_sel="NEID"
+            )
+            # save the stitched spectrum
+            self.set_data("STITCHED_CORR_TRACE1_FLUX", st_flux)
+            self.set_data("STITCHED_CORR_TRACE1_WAVE", st_wave)
+            phead["BLZCORR"] = True
+            phead["LMPCORR"] = True
+            phead["SEDCORR"] = False
+            phead["INTERPMD"] = 'BINDENSITY'
+            phead["FLXNRMMD"] = 'None'
+            phead["DISPCORR"] = True
+            self.set_header("PRIMARY", phead)
 
-        # save the stitched spectrum
-        self.set_data("STITCHED_CORR_TRACE1_FLUX", st_flux)
-        self.set_data("STITCHED_CORR_TRACE1_WAVE", st_wave)
+        except Exception as e:
+            print(f"Error stitching orders: {e}")
+            st_wave, st_flux = None, None
+            phead["BLZCORR"] = False
+            phead["LMPCORR"] = False
+            phead["SEDCORR"] = False
+            phead["INTERPMD"] = 'None'
+            phead["FLXNRMMD"] = 'None'
+            phead["DISPCORR"] = False
+            self.set_header("PRIMARY", phead)
+        
 
         # self.set_header("DRP_CONFIG", OrderedDict(hdul2["CONFIG"].header))
         # self.set_data("DRP_CONFIG", Table(hdul2["CONFIG"].data).to_pandas())

--- a/rvdata/instruments/neid/level3.py
+++ b/rvdata/instruments/neid/level3.py
@@ -2,8 +2,6 @@ from astropy.io import fits
 
 # from astropy.table import Table
 import numpy as np
-import pandas as pd
-import os
 
 # from collections import OrderedDict
 

--- a/rvdata/tests/regression/test_neid.py
+++ b/rvdata/tests/regression/test_neid.py
@@ -8,7 +8,7 @@ from rvdata.tests.regression.compliance import check_l4_extensions, check_l4_hea
 
 file_urls = {
     "NEID": {
-        "NATIVE_L2": "",
+        "NATIVE_L2": "https://zenodo.org/records/17794590/files/neidL2_20231010T020006.fits?download=1",
     }
 }
 


### PR DESCRIPTION
Convert NEID Level 2 spectral data to a Level 3 FITS file, as well as several improvements and corrections to the FITS keyword configuration files and a couple of bugfixes in the FITS reading logic. The most important changes are summarized below:

**New Tutorial and Documentation:**

* Added a Jupyter notebook (`docs/tutorials/level3datastandard_from_NEIDlevel2_example.ipynb`) that demonstrates the process of loading NEID Level 2 data, converting it to a Level 3 object, writing/reading Level 3 FITS files, and visualizing the stitched spectrum using `matplotlib`.

**FITS Keyword Configuration Improvements:**

* Standardized the formatting of default values in `rvdata/core/models/config/L2-PRIMARY-keywords.csv` by replacing empty-string defaults (`''`) with explicit empty fields, and updated comments for consistency. Also improved descriptions and formatting for several keywords. [[1]](diffhunk://#diff-82309d608158e67a9d188a0ccdb5ebd4c6b803d9643ed52cdab5cd6e898236a3L4-R16) [[2]](diffhunk://#diff-82309d608158e67a9d188a0ccdb5ebd4c6b803d9643ed52cdab5cd6e898236a3L31-R90)
* Updated `rvdata/core/models/config/L3-PRIMARY-keywords.csv` to clarify and standardize default values, required flags, and notes for Level 3 FITS keywords, especially for SED correction, lamp correction, interpolation, and normalization methods.

**Bug Fixes and Code Corrections:**

* Fixed a bug in `rvdata/core/models/base.py` where the Level 3 FITS reading logic incorrectly referenced the Level 4 class; it now correctly uses the Level 3 class for reading.
* Minor code fix to ensure that the Table is only read for "RECEIPT" HDUs, which prevents unnecessary operations for other HDU types.