### PR TITLE
Add KPF Level 3 Support

### DIFF
--- a/rvdata/core/models/level3.py
+++ b/rvdata/core/models/level3.py
@@ -80,6 +80,8 @@ class RV3(rvdata.core.models.base.RVDataModel):
         self.set_data("ORDER_TABLE", pd.DataFrame(columns=order_table_columns))
 
     def _read(self, hdul: fits.HDUList) -> None:
+        import warnings
+
         l3_ext = LEVEL3_EXTENSIONS.set_index("Name")
         for hdu in hdul:
             # Get DataType from predefined extensions, or infer from HDU type
@@ -89,8 +91,21 @@ class RV3(rvdata.core.models.base.RVDataModel):
                 fits_type = "PrimaryHDU"
             elif isinstance(hdu, fits.ImageHDU):
                 fits_type = "ImageHDU"
+                # Warn about non-standard extensions (except dynamic TRACE extensions)
+                if not hdu.name.startswith("STITCHED_CORR_TRACE"):
+                    warnings.warn(
+                        f"Non-standard extension '{hdu.name}' found in L3 file. "
+                        "This may indicate a malformed file.",
+                        UserWarning,
+                    )
             elif isinstance(hdu, fits.BinTableHDU):
                 fits_type = "BinTableHDU"
+                if hdu.name not in ["EXT_DESCRIPT", "RECEIPT", "DRP_CONFIG", "ORDER_TABLE"]:
+                    warnings.warn(
+                        f"Non-standard table extension '{hdu.name}' found in L3 file. "
+                        "This may indicate a malformed file.",
+                        UserWarning,
+                    )
             else:
                 continue  # Skip unknown HDU types
 
@@ -182,8 +197,8 @@ class RV3(rvdata.core.models.base.RVDataModel):
         for trace_num in traces:
             this_trace = str(l3prihdr[f"TRACE{trace_num}"]).strip()
             clsrc = l3prihdr[f"CLSRC{trace_num}"]
-            # Check for None (Python) or "None" (string from FITS header)
-            clsrc_is_none = (clsrc is None) or (str(clsrc).strip().lower() == "none")
+            # Check for None (Python None or string "None" from FITS header)
+            clsrc_is_none = clsrc is None or (isinstance(clsrc, str) and clsrc.strip().lower() == "none")
             if clsrc_is_none and (this_trace.lower() != "sky"):
                 traces2stitch.append(trace_num)
             else:
@@ -261,6 +276,10 @@ class RV3(rvdata.core.models.base.RVDataModel):
                 pass
         elif len(traces2stitch) > 1:
             # set STITCHED_CORR_TRACE{n}_WAVE/FLUX/VAR for each trace
+            # Note: The L3 standard defines STITCHED_CORR_TRACE1_* as optional extensions.
+            # For multi-trace instruments (e.g., KPF with 3 science fibers), we dynamically
+            # create TRACE{n} extensions for each science trace. This is an intentional
+            # extension of the standard to support instruments with multiple science fibers.
             for trace_num in traces2stitch:
                 try:
                     # Create extensions if they don't exist (they're optional)

--- a/rvdata/core/models/level3.py
+++ b/rvdata/core/models/level3.py
@@ -82,7 +82,18 @@ class RV3(rvdata.core.models.base.RVDataModel):
     def _read(self, hdul: fits.HDUList) -> None:
         l3_ext = LEVEL3_EXTENSIONS.set_index("Name")
         for hdu in hdul:
-            fits_type = l3_ext.loc[hdu.name]["DataType"]
+            # Get DataType from predefined extensions, or infer from HDU type
+            if hdu.name in l3_ext.index:
+                fits_type = l3_ext.loc[hdu.name]["DataType"]
+            elif isinstance(hdu, fits.PrimaryHDU):
+                fits_type = "PrimaryHDU"
+            elif isinstance(hdu, fits.ImageHDU):
+                fits_type = "ImageHDU"
+            elif isinstance(hdu, fits.BinTableHDU):
+                fits_type = "BinTableHDU"
+            else:
+                continue  # Skip unknown HDU types
+
             if hdu.name not in self.extensions.keys():
                 self.create_extension(hdu.name, fits_type)
 
@@ -269,6 +280,18 @@ class RV3(rvdata.core.models.base.RVDataModel):
                 except KeyError:
                     pass
             # TODO: if there are multiple traces, co-add all traces to produce the "SCI" extensions
+
+            # Update EXT_DESCRIPT table with new trace extensions
+            ext_descript = self.data["EXT_DESCRIPT"]
+            for trace_num in traces2stitch:
+                for suffix in ["WAVE", "FLUX", "VAR"]:
+                    ext_name = f"STITCHED_CORR_TRACE{trace_num}_{suffix}"
+                    if ext_name not in ext_descript["Name"].values:
+                        new_row = pd.DataFrame(
+                            {"Name": [ext_name], "Description": [f"Stitched trace {trace_num} {suffix.lower()}"]}
+                        )
+                        ext_descript = pd.concat([ext_descript, new_row], ignore_index=True)
+            self.set_data("EXT_DESCRIPT", ext_descript)
 
         # set the order table from level 2 data into level 3 object
         self.set_data("ORDER_TABLE", order_table)

--- a/rvdata/core/models/level3.py
+++ b/rvdata/core/models/level3.py
@@ -170,9 +170,10 @@ class RV3(rvdata.core.models.base.RVDataModel):
         traces2stitch = []
         for trace_num in traces:
             this_trace = str(l3prihdr[f"TRACE{trace_num}"]).strip()
-            if (l3prihdr[f"CLSRC{trace_num}"] is None) and (
-                this_trace.lower() != "sky"
-            ):
+            clsrc = l3prihdr[f"CLSRC{trace_num}"]
+            # Check for None (Python) or "None" (string from FITS header)
+            clsrc_is_none = (clsrc is None) or (str(clsrc).strip().lower() == "none")
+            if clsrc_is_none and (this_trace.lower() != "sky"):
                 traces2stitch.append(trace_num)
             else:
                 continue
@@ -251,6 +252,11 @@ class RV3(rvdata.core.models.base.RVDataModel):
             # set STITCHED_CORR_TRACE{n}_WAVE/FLUX/VAR for each trace
             for trace_num in traces2stitch:
                 try:
+                    # Create extensions if they don't exist (they're optional)
+                    for suffix in ["WAVE", "FLUX", "VAR"]:
+                        ext_name = f"STITCHED_CORR_TRACE{trace_num}_{suffix}"
+                        if ext_name not in self.extensions:
+                            self.create_extension(ext_name, "ImageHDU")
                     self.set_data(
                         f"STITCHED_CORR_TRACE{trace_num}_WAVE", st_wav[trace_num]
                     )

--- a/rvdata/core/tools/stitch_spectrum.py
+++ b/rvdata/core/tools/stitch_spectrum.py
@@ -443,8 +443,10 @@ def mask_bad_spectrum_data(sci_flx, sci_wav, sci_blz, sci_var):
     """
 
     # Create masks for bad data
-    # Note: blaze threshold is set to 0 to handle both raw (counts) and
-    # normalized (0-1) blaze functions from different instruments
+    # Note on blaze threshold: Set to 0 (not 1.0) to handle both raw blaze
+    # functions (counts, can be >1e6) and normalized blaze functions (0-1).
+    # This global threshold works for all supported instruments (NEID, KPF,
+    # ESPRESSO, HARPS, HARPSN, EXPRES) since valid blaze values are always > 0.
     sciflx_mask = (sci_flx <= 1.0) | np.isnan(sci_flx)
     sciwav_mask = (sci_wav <= 0.0) | np.isnan(sci_wav)
     sciblz_mask = (sci_blz <= 0.0) | np.isnan(sci_blz)
@@ -513,7 +515,10 @@ def calculate_normalized_blaze_function(
     sci_wav : np.ndarray
         Science wavelength array.
     sci_blz : np.ndarray
-        Science blaze array.
+        Science blaze array. Can be raw (counts) or pre-normalized.
+        The function normalizes by dividing by an envelope fit to the
+        blaze peaks, so the output will have maximum values near 1.0
+        regardless of the input scale.
     inst_stitch_config : dict
         Instrument stitching configuration dictionary.
     order_table : pandas.DataFrame
@@ -522,7 +527,9 @@ def calculate_normalized_blaze_function(
     Returns:
     --------
     np.ndarray
-        The normalized blaze function array.
+        The normalized blaze function array with maximum values near 1.0.
+        Each order's blaze is divided by an envelope fit through the
+        blaze peaks across orders.
     """
     # Initialize normalized blaze array
     sci_blze = np.full_like(sci_blz, fill_value=np.nan)
@@ -601,8 +608,21 @@ def stitch_deblazed_spectrum(wavegrid, sci_wav, sci_dflx, sci_dcov, min_orders=1
     """
     # Check wavelength direction and flip if decreasing
     # bindensity requires strictly increasing wavelengths
-    sample_order = sci_wav.shape[0] // 2
-    wav_diff = np.nanmean(np.diff(sci_wav[sample_order, :]))
+    # Try multiple orders to find one with sufficient valid data for direction check
+    n_orders = sci_wav.shape[0]
+    wav_diff = np.nan
+    for offset in [0, 1, -1, 2, -2]:
+        sample_order = n_orders // 2 + offset
+        if 0 <= sample_order < n_orders:
+            order_wav = sci_wav[sample_order, :]
+            valid_mask = np.isfinite(order_wav)
+            if np.sum(valid_mask) > 10:  # Need at least 10 valid points
+                wav_diff = np.nanmean(np.diff(order_wav))
+                if np.isfinite(wav_diff):
+                    break
+    # Fallback: if no order has enough valid data, assume increasing
+    if not np.isfinite(wav_diff):
+        wav_diff = 1.0  # Assume increasing wavelengths
     if wav_diff < 0:
         # Wavelengths are decreasing, flip all arrays along pixel axis
         sci_wav = sci_wav[:, ::-1]

--- a/rvdata/core/tools/stitch_spectrum.py
+++ b/rvdata/core/tools/stitch_spectrum.py
@@ -443,9 +443,11 @@ def mask_bad_spectrum_data(sci_flx, sci_wav, sci_blz, sci_var):
     """
 
     # Create masks for bad data
+    # Note: blaze threshold is set to 0 to handle both raw (counts) and
+    # normalized (0-1) blaze functions from different instruments
     sciflx_mask = (sci_flx <= 1.0) | np.isnan(sci_flx)
     sciwav_mask = (sci_wav <= 0.0) | np.isnan(sci_wav)
-    sciblz_mask = (sci_blz <= 1.0) | np.isnan(sci_blz)
+    sciblz_mask = (sci_blz <= 0.0) | np.isnan(sci_blz)
     spec_mask = sciflx_mask | sciwav_mask | sciblz_mask
 
     # Mask data where the spectrum is bad or missing
@@ -585,7 +587,8 @@ def stitch_deblazed_spectrum(wavegrid, sci_wav, sci_dflx, sci_dcov, min_orders=1
     wavegrid : np.ndarray
         Common wavelength grid to stitch onto.
     sci_wav : np.ndarray
-        Science wavelength array for each order.
+        Science wavelength array for each order. Can be in increasing or
+        decreasing order along the pixel axis.
     sci_dflx : np.ndarray
         Deblazed science flux array for each order.
     sci_dcov : np.ndarray
@@ -596,6 +599,16 @@ def stitch_deblazed_spectrum(wavegrid, sci_wav, sci_dflx, sci_dcov, min_orders=1
     tuple
         Stitched wavelength array, stitched flux array, stitched variance array.
     """
+    # Check wavelength direction and flip if decreasing
+    # bindensity requires strictly increasing wavelengths
+    sample_order = sci_wav.shape[0] // 2
+    wav_diff = np.nanmean(np.diff(sci_wav[sample_order, :]))
+    if wav_diff < 0:
+        # Wavelengths are decreasing, flip all arrays along pixel axis
+        sci_wav = sci_wav[:, ::-1]
+        sci_dflx = sci_dflx[:, ::-1]
+        sci_dcov = sci_dcov[:, :, ::-1]
+
     # Rebin each order (flux-conserving with bindensity package)
     flx_stack = []
     var_stack = []

--- a/rvdata/instruments/kpf/config/kpf_level3.config
+++ b/rvdata/instruments/kpf/config/kpf_level3.config
@@ -1,6 +1,9 @@
 [STITCHPARS]
 instrument = KPF
 # Trace selection to stitch (e.g 1-3,4,6)
+# For KPF, traces 2,3,4 correspond to the three science fibers (SCI1, SCI2, SCI3).
+# These map to KPF's internal TRACE2, TRACE3, TRACE4 (not TRACE1-TRACE3).
+# TRACE1 is the calibration fiber and TRACE5 is the sky fiber.
 trace_selection = 2,3,4
 # Echelle orders for blue segment start
 echorder_blue_start = 137

--- a/rvdata/instruments/kpf/config/kpf_level3.config
+++ b/rvdata/instruments/kpf/config/kpf_level3.config
@@ -1,0 +1,18 @@
+[STITCHPARS]
+instrument = KPF
+# Trace selection to stitch (e.g 1-3,4,6)
+trace_selection = 2,3,4
+# Echelle orders for blue segment start
+echorder_blue_start = 137
+# Echelle orders for blue segment end. Leave blank for single flat source
+echorder_blue_end =
+# Echelle orders for red segment start. Leave blank for single flat source
+echorder_red_start =
+# Echelle orders for red segment end
+echorder_red_end = 71
+# Start wavelength (A) of the stitched wavelength grid
+wavegrid_start = 4450.0
+# End wavelength (A) of the stitched wavelength grid
+wavegrid_end = 8710.0
+# Average pixel width in velocity space (m/s) across all orders. Leave blank to calculate from wavelength array
+velpix = 886.0

--- a/rvdata/instruments/kpf/level3.py
+++ b/rvdata/instruments/kpf/level3.py
@@ -1,0 +1,62 @@
+from astropy.io import fits
+
+# import base class
+from rvdata.core.models.level3 import RV3
+from rvdata.core.models.level2 import RV2
+
+
+# KPF Level3 Reader
+class KPFRV3(RV3):
+    """
+    Data model and reader for RVData Level 3 (stitched spectrum) data
+    constructed from KPF Level 2 data.
+
+    This class extends the `RV3` base class to handle Keck Planet Finder (KPF)
+    data. It reads the relevant science and calibration extensions
+    from a KPF Level 2 file and produces a stitched 1D spectrum.
+
+    KPF has 5 traces:
+    - TRACE1: Calibration fiber (CAL)
+    - TRACE2, TRACE3, TRACE4: Science fibers (SCI1, SCI2, SCI3)
+    - TRACE5: Sky fiber (SKY)
+
+    The three science traces (TRACE2, TRACE3, TRACE4) are stitched individually.
+    When multiple traces are present, they are stored in STITCHED_CORR_TRACE{n}_*
+    extensions.
+
+    Parameters
+    ----------
+    Inherits all parameters from :class:`RV3`.
+
+    Attributes
+    ----------
+    extensions : dict
+        Dictionary of all created extensions
+        (e.g., 'STITCHED_CORR_SCI_FLUX', 'STITCHED_CORR_SCI_WAVE', etc.),
+        mapping extension names to their data arrays.
+    headers : dict
+        Dictionary of headers for each extension, mapping extension names to
+        their FITS headers.
+    data : dict
+        Dictionary of data arrays for each extension.
+
+    Notes
+    -----
+    To construct an RVData Level 3 object, a KPF Level 2 standard FITS file
+    is required. The classmethod `from_fits` should be used to
+    instantiate the object from these files. The `_read` method is not intended
+    to be called directly by users.
+
+    Example
+    -------
+    >>> from rvdata.instruments.kpf.level3 import KPFRV3
+    >>> obj = KPFRV3.from_fits("kpf_L2_standard.fits")
+    >>> obj.to_fits("kpf_L3_standard.fits")
+    """
+
+    def _read(self, hdul2: fits.HDUList, **kwargs) -> None:
+        # Read the RVData L2 standard file using base RV2 class
+        # (KPFRV2 is for native KPF L0+L1 files, not standard L2 files)
+        l2obj = RV2()
+        l2obj.read(hdul2, instrument=None)
+        self.convert_level2_to_level3(l2obj)

--- a/rvdata/instruments/kpf/level3.py
+++ b/rvdata/instruments/kpf/level3.py
@@ -22,7 +22,11 @@ class KPFRV3(RV3):
 
     The three science traces (TRACE2, TRACE3, TRACE4) are stitched individually.
     When multiple traces are present, they are stored in STITCHED_CORR_TRACE{n}_*
-    extensions.
+    extensions (e.g., STITCHED_CORR_TRACE2_FLUX, STITCHED_CORR_TRACE3_FLUX, etc.).
+
+    Note: The STITCHED_CORR_SCI_* extensions are currently not populated when
+    multiple traces are present. A future enhancement will co-add all science
+    traces to produce these combined "SCI" extensions.
 
     Parameters
     ----------
@@ -42,10 +46,12 @@ class KPFRV3(RV3):
 
     Notes
     -----
-    To construct an RVData Level 3 object, a KPF Level 2 standard FITS file
-    is required. The classmethod `from_fits` should be used to
-    instantiate the object from these files. The `_read` method is not intended
-    to be called directly by users.
+    To construct an RVData Level 3 object, an RVData-standard Level 2 FITS file
+    is required. Native KPF Level 2 files are not directly supported; they must
+    first be converted to RVData-standard format using KPFRV2.from_fits().
+
+    The classmethod `from_fits` should be used to instantiate the object from
+    these files. The `_read` method is not intended to be called directly by users.
 
     Example
     -------

--- a/rvdata/tests/regression/test_kpf.py
+++ b/rvdata/tests/regression/test_kpf.py
@@ -50,6 +50,8 @@ def test_kpf():
     check_l2_header(l2_obj.headers['PRIMARY'])
 
     # Check L3
+    # Note: L3 creation requires an RVData-standard L2 file (created above).
+    # Native KPF L2 files must first be converted using KPFRV2.from_fits().
     kpf3 = RV3.from_fits(l2_standard, instrument="KPF")
     l3_standard = "./kpf_L3_standard.fits"
     kpf3.to_fits(l3_standard)

--- a/rvdata/tests/regression/test_kpf.py
+++ b/rvdata/tests/regression/test_kpf.py
@@ -1,9 +1,11 @@
 import requests
 import os
 from rvdata.core.models.level2 import RV2
+from rvdata.core.models.level3 import RV3
 from rvdata.core.models.level4 import RV4
 
 from rvdata.tests.regression.compliance import check_l2_extensions, check_l2_header
+from rvdata.tests.regression.compliance import check_l3_extensions, check_l3_header
 from rvdata.tests.regression.compliance import check_l4_extensions, check_l4_header
 
 
@@ -47,6 +49,16 @@ def test_kpf():
     check_l2_extensions(l2_standard)
     check_l2_header(l2_obj.headers['PRIMARY'])
 
+    # Check L3
+    kpf3 = RV3.from_fits(l2_standard, instrument="KPF")
+    l3_standard = "./kpf_L3_standard.fits"
+    kpf3.to_fits(l3_standard)
+    l3_obj = RV3.from_fits(l3_standard)
+
+    check_l3_extensions(l3_standard)
+    check_l3_header(l3_obj.headers['PRIMARY'])
+
+    # Check L4
     kpf4 = RV4.from_fits(l2file, instrument="KPF")
     l4_standard = "./kpf_L4_standard.fits"
     kpf4.to_fits(l4_standard)


### PR DESCRIPTION
- Add KPF Level 3 reader (KPFRV3) and config file
- Fix wavelength direction handling in stitch_deblazed_spectrum for instruments with decreasing wavelengths (KPF)
- Fix blaze masking threshold to handle normalized blaze functions (0-1)
- Fix CLSRC comparison to handle string "None" from FITS headers
- Add automatic creation of (optional) STITCHED_CORR_TRACE{n}_* extensions for multi-trace instruments