### PR TITLE
Handle UNDEFINED values in FITS headers

### DIFF
--- a/rvdata/core/tools/headers.py
+++ b/rvdata/core/tools/headers.py
@@ -2,6 +2,7 @@ import unicodedata
 import warnings
 
 import numpy as np
+from astropy.io.fits.card import Undefined
 
 
 def to_ascii_safe(input_string):
@@ -43,7 +44,9 @@ def parse_value_to_datatype(keyword: str, datatype: str, in_value):
     try:
         if value is None:
             out_value = None
-        elif isinstance(value, str) and value.lower() == "undefined":
+        elif isinstance(value, Undefined):
+            out_value = None
+        elif isinstance(value, str) and (value.strip() == "" or value.lower() == "undefined"):
             out_value = None
         elif datatype.lower() == "uint":
             out_value = int(value)

--- a/rvdata/tests/test_headers.py
+++ b/rvdata/tests/test_headers.py
@@ -1,5 +1,9 @@
 # Tests for core.tools.headers module
-from rvdata.core.tools.headers import to_ascii_safe
+import warnings
+
+from astropy.io.fits.card import Undefined
+
+from rvdata.core.tools.headers import parse_value_to_datatype, to_ascii_safe
 
 
 def test_to_ascii_safe_clean():
@@ -8,3 +12,47 @@ def test_to_ascii_safe_clean():
 
 def test_to_ascii_safe_unicode():
     assert to_ascii_safe("äbc") == "abc"
+
+
+def test_parse_value_to_datatype_none():
+    """Test that None values are handled correctly."""
+    result = parse_value_to_datatype("TEST", "uint", None)
+    assert result == (None, "")
+
+
+def test_parse_value_to_datatype_undefined_object():
+    """Test that astropy Undefined objects are handled correctly."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # Turn warnings into errors
+        result = parse_value_to_datatype("TEST", "uint", Undefined())
+    assert result == (None, "")
+
+
+def test_parse_value_to_datatype_undefined_string():
+    """Test that 'UNDEFINED' string is handled correctly."""
+    result = parse_value_to_datatype("TEST", "uint", "UNDEFINED")
+    assert result == (None, "")
+    result = parse_value_to_datatype("TEST", "uint", "undefined")
+    assert result == (None, "")
+
+
+def test_parse_value_to_datatype_empty_string():
+    """Test that empty and whitespace strings are handled correctly."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # Turn warnings into errors
+        result = parse_value_to_datatype("TEST", "uint", "")
+        assert result == (None, "")
+        result = parse_value_to_datatype("TEST", "uint", " ")
+        assert result == (None, "")
+        result = parse_value_to_datatype("TEST", "uint", "   ")
+        assert result == (None, "")
+
+
+def test_parse_value_to_datatype_valid_values():
+    """Test that valid values are still converted correctly."""
+    assert parse_value_to_datatype("TEST", "uint", 42) == (42, "")
+    assert parse_value_to_datatype("TEST", "uint", "42") == (42, "")
+    assert parse_value_to_datatype("TEST", "float", 3.14) == (3.14, "")
+    assert parse_value_to_datatype("TEST", "string", "hello") == ("hello", "")
+    assert parse_value_to_datatype("TEST", "boolean", True) == (True, "")
+    assert parse_value_to_datatype("TEST", "boolean", "True") == (True, "")


### PR DESCRIPTION
## Summary

- Fix issue #121 where FITS header values could trigger warnings when they are undefined
- Handle `astropy.io.fits.card.Undefined` objects
- Handle empty strings `''` and whitespace-only strings `' '`
- These now correctly return `None` without warnings

## Test plan

- [x] Verified fix handles all undefined value types without warnings
- [x] Added unit tests for `parse_value_to_datatype` covering:
  - `None` values
  - `Undefined` objects
  - `'UNDEFINED'` strings
  - Empty and whitespace strings
  - Valid values still convert correctly
- [x] All tests pass

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)