### PR TITLE
Enforce EPRV filename convention

### DIFF
--- a/rvdata/core/models/base.py
+++ b/rvdata/core/models/base.py
@@ -6,6 +6,7 @@ import datetime
 import hashlib
 import importlib
 import os
+import re
 import warnings
 from collections import OrderedDict
 
@@ -242,11 +243,21 @@ class RVDataModel(object):
 
         Note:
             Can only write to KPF formatted FITS
+            Filename should follow the EPRV naming convention:
+            inst_SL#_YYYYMMDDThhmmss.fits
 
         """
         if not fn.endswith(".fits"):
             # we only want to write to a '.fits file
             raise NameError("filename must end with .fits")
+
+        # Check filename convention and warn if it doesn't match
+        self.check_filename_convention(fn)
+
+        # Update FILENAME header to match the actual filename being written
+        basename = os.path.basename(fn)
+        if "PRIMARY" in self.headers:
+            self.headers["PRIMARY"]["FILENAME"] = (basename, "Name of the FITS file")
 
         hdu_list = self._create_hdul()
         # finish up writing
@@ -256,6 +267,112 @@ class RVDataModel(object):
             os.makedirs(dirname, exist_ok=True)
         hdul.writeto(fn, overwrite=True, output_verify="silentfix")
         hdul.close()
+
+    # =============================================================================
+    # Filename convention methods
+
+    # Pattern for standard filename: inst_SL#_YYYYMMDDThhmmss.fits
+    FILENAME_PATTERN = re.compile(
+        r"^([a-zA-Z]+)_SL([234])_(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.fits$"
+    )
+
+    def generate_standard_filename(self):
+        """
+        Generate a standard filename based on the EPRV naming convention.
+
+        The convention is: inst_SL#_YYYYMMDDThhmmss.fits
+        where:
+        - inst: instrument name (lowercase)
+        - SL#: standard level (SL2, SL3, or SL4)
+        - YYYYMMDDThhmmss: observation date/time
+
+        Returns:
+            str: The generated standard filename
+
+        Raises:
+            ValueError: If required header values (INSTRUME, DATE-OBS) are missing
+                or if the data level is not set
+        """
+        # Get instrument name from PRIMARY header
+        if "PRIMARY" not in self.headers:
+            raise ValueError("PRIMARY header not found")
+
+        instrume = self.headers["PRIMARY"].get("INSTRUME")
+        if instrume is None:
+            raise ValueError("INSTRUME keyword not found in PRIMARY header")
+        # Handle tuple format (value, comment)
+        if isinstance(instrume, tuple):
+            instrume = instrume[0]
+        instrume = str(instrume).lower()
+
+        # Get level
+        if self.level is None:
+            raise ValueError("Data level not set")
+        level = self.level
+
+        # Get DATE-OBS from PRIMARY header
+        date_obs = self.headers["PRIMARY"].get("DATE-OBS")
+        if date_obs is None:
+            raise ValueError("DATE-OBS keyword not found in PRIMARY header")
+        # Handle tuple format (value, comment)
+        if isinstance(date_obs, tuple):
+            date_obs = date_obs[0]
+
+        # Parse DATE-OBS (format: YYYY-MM-DDTHH:MM:SS.sss or similar)
+        # Remove any fractional seconds and parse
+        date_str = str(date_obs).split(".")[0]  # Remove fractional seconds
+        try:
+            dt = datetime.datetime.fromisoformat(date_str)
+        except ValueError:
+            raise ValueError(f"Cannot parse DATE-OBS value: {date_obs}")
+
+        # Format as YYYYMMDDThhmmss
+        datetime_str = dt.strftime("%Y%m%dT%H%M%S")
+
+        return f"{instrume}_SL{level}_{datetime_str}.fits"
+
+    def validate_filename(self, filename):
+        """
+        Validate if a filename matches the EPRV naming convention.
+
+        The convention is: inst_SL#_YYYYMMDDThhmmss.fits
+
+        Args:
+            filename (str): The filename to validate (basename only, no path)
+
+        Returns:
+            bool: True if the filename matches the convention, False otherwise
+        """
+        # Get just the basename if a path was provided
+        basename = os.path.basename(filename)
+        return bool(self.FILENAME_PATTERN.match(basename))
+
+    def check_filename_convention(self, filename):
+        """
+        Check if the filename follows the EPRV naming convention and issue
+        a warning if it doesn't.
+
+        Args:
+            filename (str): The filename to check
+
+        Returns:
+            bool: True if the filename matches the convention, False otherwise
+        """
+        basename = os.path.basename(filename)
+        if not self.validate_filename(basename):
+            try:
+                suggested = self.generate_standard_filename()
+                warnings.warn(
+                    f"Filename '{basename}' does not follow the EPRV naming convention. "
+                    f"Suggested filename: '{suggested}'"
+                )
+            except ValueError:
+                warnings.warn(
+                    f"Filename '{basename}' does not follow the EPRV naming convention "
+                    f"(inst_SL#_YYYYMMDDThhmmss.fits)"
+                )
+            return False
+        return True
 
     # =============================================================================
     # Receipt related members

--- a/rvdata/core/models/base.py
+++ b/rvdata/core/models/base.py
@@ -234,18 +234,26 @@ class RVDataModel(object):
                 parsed_value = parse_value_to_datatype(key, row["DataType"], value)
                 self.headers["PRIMARY"][key] = parsed_value
 
-    def to_fits(self, fn):
+    def to_fits(self, fn=None):
         """
         Collect the content of this instance into a monolithic FITS file
 
         Args:
-            fn (str): file path
+            fn (str, optional): file path. If not provided, automatically
+                generates a filename following the EPRV naming convention.
+
+        Returns:
+            str: The filename that was written to
 
         Note:
             Filename should follow the EPRV naming convention:
             inst_SL#_YYYYMMDDThhmmss.fits
 
         """
+        # Auto-generate filename if not provided
+        if fn is None:
+            fn = self.generate_standard_filename()
+
         if not fn.endswith(".fits"):
             # we only want to write to a '.fits file
             raise NameError("filename must end with .fits")
@@ -266,6 +274,8 @@ class RVDataModel(object):
             os.makedirs(dirname, exist_ok=True)
         hdul.writeto(fn, overwrite=True, output_verify="silentfix")
         hdul.close()
+
+        return fn
 
     # =============================================================================
     # Filename convention methods

--- a/rvdata/core/models/base.py
+++ b/rvdata/core/models/base.py
@@ -242,7 +242,6 @@ class RVDataModel(object):
             fn (str): file path
 
         Note:
-            Can only write to KPF formatted FITS
             Filename should follow the EPRV naming convention:
             inst_SL#_YYYYMMDDThhmmss.fits
 

--- a/rvdata/tests/regression/test_espresso.py
+++ b/rvdata/tests/regression/test_espresso.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import requests
 
+from rvdata.core.models.base import RVDataModel
 from rvdata.core.models.level2 import RV2
 from rvdata.core.models.level4 import RV4
 from rvdata.tests.regression.compliance import (
@@ -60,20 +61,26 @@ def test_espresso():
     files = download_instrument_files("ESPRESSO")
     raw_file = files["raw"]
 
-    # Test Level 2
+    # Test Level 2 - use auto-generated filename
     espr2 = RV2.from_fits(str(raw_file), instrument="ESPRESSO")
-    l2_standard = Path("esp_L2_standard.fits")
-    espr2.to_fits(str(l2_standard))
-    l2_obj = RV2.from_fits(str(l2_standard))
-    check_l2_extensions(str(l2_standard))
+    l2_standard = espr2.to_fits()  # Auto-generate filename
+    assert RVDataModel.FILENAME_PATTERN.match(os.path.basename(l2_standard)), \
+        f"L2 filename '{l2_standard}' does not match EPRV convention"
+    assert l2_standard.startswith("espresso_SL2_"), \
+        f"L2 filename should start with 'espresso_SL2_', got '{l2_standard}'"
+    l2_obj = RV2.from_fits(l2_standard)
+    check_l2_extensions(l2_standard)
     check_l2_header(l2_obj.headers["PRIMARY"])
 
-    # Test Level 4
+    # Test Level 4 - use auto-generated filename
     espr4 = RV4.from_fits(str(raw_file), instrument="ESPRESSO")
-    l4_standard = Path("espr_L4_standard.fits")
-    espr4.to_fits(str(l4_standard))
-    l4_obj = RV4.from_fits(str(l4_standard))
-    check_l4_extensions(str(l4_standard))
+    l4_standard = espr4.to_fits()  # Auto-generate filename
+    assert RVDataModel.FILENAME_PATTERN.match(os.path.basename(l4_standard)), \
+        f"L4 filename '{l4_standard}' does not match EPRV convention"
+    assert l4_standard.startswith("espresso_SL4_"), \
+        f"L4 filename should start with 'espresso_SL4_', got '{l4_standard}'"
+    l4_obj = RV4.from_fits(l4_standard)
+    check_l4_extensions(l4_standard)
     check_l4_header(l4_obj.headers["PRIMARY"])
 
 

--- a/rvdata/tests/regression/test_kpf.py
+++ b/rvdata/tests/regression/test_kpf.py
@@ -1,5 +1,6 @@
 import requests
 import os
+from rvdata.core.models.base import RVDataModel
 from rvdata.core.models.level2 import RV2
 from rvdata.core.models.level3 import RV3
 from rvdata.core.models.level4 import RV4
@@ -41,9 +42,14 @@ def download_files():
 
 def test_kpf():
     l0file, l1file, l2file = download_files()
+
+    # Check L2 - use auto-generated filename
     kpf2 = RV2.from_fits(l1file, l0file=l0file, instrument="KPF")
-    l2_standard = "./kpf_L2_standard.fits"
-    kpf2.to_fits(l2_standard)
+    l2_standard = kpf2.to_fits()  # Auto-generate filename
+    assert RVDataModel.FILENAME_PATTERN.match(os.path.basename(l2_standard)), \
+        f"L2 filename '{l2_standard}' does not match EPRV convention"
+    assert l2_standard.startswith("kpf_SL2_"), \
+        f"L2 filename should start with 'kpf_SL2_', got '{l2_standard}'"
     l2_obj = RV2.from_fits(l2_standard)
 
     check_l2_extensions(l2_standard)
@@ -53,17 +59,23 @@ def test_kpf():
     # Note: L3 creation requires an RVData-standard L2 file (created above).
     # Native KPF L2 files must first be converted using KPFRV2.from_fits().
     kpf3 = RV3.from_fits(l2_standard, instrument="KPF")
-    l3_standard = "./kpf_L3_standard.fits"
-    kpf3.to_fits(l3_standard)
+    l3_standard = kpf3.to_fits()  # Auto-generate filename
+    assert RVDataModel.FILENAME_PATTERN.match(os.path.basename(l3_standard)), \
+        f"L3 filename '{l3_standard}' does not match EPRV convention"
+    assert l3_standard.startswith("kpf_SL3_"), \
+        f"L3 filename should start with 'kpf_SL3_', got '{l3_standard}'"
     l3_obj = RV3.from_fits(l3_standard)
 
     check_l3_extensions(l3_standard)
     check_l3_header(l3_obj.headers['PRIMARY'])
 
-    # Check L4
+    # Check L4 - use auto-generated filename
     kpf4 = RV4.from_fits(l2file, instrument="KPF")
-    l4_standard = "./kpf_L4_standard.fits"
-    kpf4.to_fits(l4_standard)
+    l4_standard = kpf4.to_fits()  # Auto-generate filename
+    assert RVDataModel.FILENAME_PATTERN.match(os.path.basename(l4_standard)), \
+        f"L4 filename '{l4_standard}' does not match EPRV convention"
+    assert l4_standard.startswith("kpf_SL4_"), \
+        f"L4 filename should start with 'kpf_SL4_', got '{l4_standard}'"
     l4_obj = RV4.from_fits(l4_standard)
 
     check_l4_extensions(l4_standard)

--- a/rvdata/tests/regression/test_neid.py
+++ b/rvdata/tests/regression/test_neid.py
@@ -1,5 +1,6 @@
 import requests
 import os
+from rvdata.core.models.base import RVDataModel
 from rvdata.core.models.level2 import RV2
 from rvdata.core.models.level3 import RV3
 from rvdata.core.models.level4 import RV4
@@ -33,28 +34,37 @@ def download_files():
 def test_neid():
     native_l2_file = download_files()
 
-    # Check L2
+    # Check L2 - use auto-generated filename
     neidl2 = RV2.from_fits(native_l2_file, instrument="NEID")
-    standard_l2_file = "./neid_L2_standard.fits"
-    neidl2.to_fits(standard_l2_file)
+    standard_l2_file = neidl2.to_fits()  # Auto-generate filename
+    assert RVDataModel.FILENAME_PATTERN.match(os.path.basename(standard_l2_file)), \
+        f"L2 filename '{standard_l2_file}' does not match EPRV convention"
+    assert standard_l2_file.startswith("neid_SL2_"), \
+        f"L2 filename should start with 'neid_SL2_', got '{standard_l2_file}'"
     neidl2_obj = RV2.from_fits(standard_l2_file)
 
     check_l2_extensions(standard_l2_file)
     check_l2_header(neidl2_obj.headers["PRIMARY"])
 
-    # Check L3
+    # Check L3 - use auto-generated filename
     neidl3 = RV3.from_fits(native_l2_file, instrument="NEID")
-    standard_l3_file = "./neid_L3_standard.fits"
-    neidl3.to_fits(standard_l3_file)
+    standard_l3_file = neidl3.to_fits()  # Auto-generate filename
+    assert RVDataModel.FILENAME_PATTERN.match(os.path.basename(standard_l3_file)), \
+        f"L3 filename '{standard_l3_file}' does not match EPRV convention"
+    assert standard_l3_file.startswith("neid_SL3_"), \
+        f"L3 filename should start with 'neid_SL3_', got '{standard_l3_file}'"
     neidl3_obj = RV3.from_fits(standard_l3_file)
 
     check_l3_extensions(standard_l3_file)
     check_l3_header(neidl3_obj.headers["PRIMARY"])
 
-    # Check L4
+    # Check L4 - use auto-generated filename
     neidl4 = RV4.from_fits(native_l2_file, instrument="NEID")
-    standard_l4_file = "./neid_L4_standard.fits"
-    neidl4.to_fits(standard_l4_file)
+    standard_l4_file = neidl4.to_fits()  # Auto-generate filename
+    assert RVDataModel.FILENAME_PATTERN.match(os.path.basename(standard_l4_file)), \
+        f"L4 filename '{standard_l4_file}' does not match EPRV convention"
+    assert standard_l4_file.startswith("neid_SL4_"), \
+        f"L4 filename should start with 'neid_SL4_', got '{standard_l4_file}'"
     neidl4_obj = RV4.from_fits(standard_l4_file)
 
     check_l4_extensions(standard_l4_file)

--- a/rvdata/tests/test_filename_convention.py
+++ b/rvdata/tests/test_filename_convention.py
@@ -162,3 +162,45 @@ class TestCheckFilenameConvention:
             assert result is False
             assert len(w) == 1
             assert "does not follow the EPRV naming convention" in str(w[0].message)
+
+
+class TestToFitsAutoFilename:
+    """Test that to_fits() auto-generates correct filenames."""
+
+    def test_to_fits_returns_filename(self):
+        """Test that to_fits() returns the filename it wrote to."""
+        import tempfile
+        import os
+
+        obj = RV2()
+        obj.headers["PRIMARY"] = OrderedDict()
+        obj.headers["PRIMARY"]["INSTRUME"] = "TEST"
+        obj.headers["PRIMARY"]["DATE-OBS"] = "2025-02-08T04:51:25"
+        obj.extensions["PRIMARY"] = None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                filename = obj.to_fits()
+                assert filename == "test_SL2_20250208T045125.fits"
+                assert os.path.exists(filename)
+            finally:
+                os.chdir(old_cwd)
+
+    def test_to_fits_with_explicit_filename_returns_that_filename(self):
+        """Test that to_fits() with explicit filename returns that filename."""
+        import tempfile
+        import os
+
+        obj = RV2()
+        obj.headers["PRIMARY"] = OrderedDict()
+        obj.headers["PRIMARY"]["INSTRUME"] = "TEST"
+        obj.headers["PRIMARY"]["DATE-OBS"] = "2025-02-08T04:51:25"
+        obj.extensions["PRIMARY"] = None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            explicit_name = os.path.join(tmpdir, "my_custom_name.fits")
+            filename = obj.to_fits(explicit_name)
+            assert filename == explicit_name
+            assert os.path.exists(filename)

--- a/rvdata/tests/test_filename_convention.py
+++ b/rvdata/tests/test_filename_convention.py
@@ -1,0 +1,164 @@
+# Tests for filename convention enforcement
+import warnings
+from collections import OrderedDict
+
+import pytest
+
+from rvdata.core.models.base import RVDataModel
+from rvdata.core.models.level2 import RV2
+from rvdata.core.models.level3 import RV3
+from rvdata.core.models.level4 import RV4
+
+
+class TestFilenamePattern:
+    """Test the filename pattern matching."""
+
+    def test_valid_filenames(self):
+        """Test that valid filenames match the pattern."""
+        valid_filenames = [
+            "kpf_SL2_20250208T045125.fits",
+            "neid_SL3_20241022T123456.fits",
+            "espresso_SL4_20220824T033756.fits",
+            "HARPS_SL2_20200101T000000.fits",
+        ]
+        for filename in valid_filenames:
+            assert RVDataModel.FILENAME_PATTERN.match(filename), f"{filename} should be valid"
+
+    def test_invalid_filenames(self):
+        """Test that invalid filenames don't match the pattern."""
+        invalid_filenames = [
+            "kpf_L2_20250208T045125.fits",  # Missing 'S'
+            "kpf_SL2_standard.fits",  # Wrong datetime format
+            "kpf_SL5_20250208T045125.fits",  # Invalid level (5)
+            "kpf_SL2_2025-02-08T04:51:25.fits",  # Wrong datetime format (with dashes/colons)
+            "kpf_SL2_20250208T045125.fit",  # Wrong extension
+            "_SL2_20250208T045125.fits",  # Missing instrument
+        ]
+        for filename in invalid_filenames:
+            assert not RVDataModel.FILENAME_PATTERN.match(filename), f"{filename} should be invalid"
+
+
+class TestGenerateStandardFilename:
+    """Test the generate_standard_filename method."""
+
+    def test_generate_filename_level2(self):
+        """Test filename generation for level 2 data."""
+        obj = RV2()
+        obj.headers["PRIMARY"] = OrderedDict()
+        obj.headers["PRIMARY"]["INSTRUME"] = "KPF"
+        obj.headers["PRIMARY"]["DATE-OBS"] = "2025-02-08T04:51:25.123"
+
+        filename = obj.generate_standard_filename()
+        assert filename == "kpf_SL2_20250208T045125.fits"
+
+    def test_generate_filename_level3(self):
+        """Test filename generation for level 3 data."""
+        obj = RV3()
+        obj.headers["PRIMARY"] = OrderedDict()
+        obj.headers["PRIMARY"]["INSTRUME"] = "NEID"
+        obj.headers["PRIMARY"]["DATE-OBS"] = "2024-10-22T12:34:56"
+
+        filename = obj.generate_standard_filename()
+        assert filename == "neid_SL3_20241022T123456.fits"
+
+    def test_generate_filename_level4(self):
+        """Test filename generation for level 4 data."""
+        obj = RV4()
+        obj.headers["PRIMARY"] = OrderedDict()
+        obj.headers["PRIMARY"]["INSTRUME"] = "ESPRESSO"
+        obj.headers["PRIMARY"]["DATE-OBS"] = "2022-08-24T03:37:56.276"
+
+        filename = obj.generate_standard_filename()
+        assert filename == "espresso_SL4_20220824T033756.fits"
+
+    def test_generate_filename_with_tuple_headers(self):
+        """Test filename generation when headers are (value, comment) tuples."""
+        obj = RV2()
+        obj.headers["PRIMARY"] = OrderedDict()
+        obj.headers["PRIMARY"]["INSTRUME"] = ("KPF", "Instrument name")
+        obj.headers["PRIMARY"]["DATE-OBS"] = ("2025-02-08T04:51:25", "Observation date")
+
+        filename = obj.generate_standard_filename()
+        assert filename == "kpf_SL2_20250208T045125.fits"
+
+    def test_generate_filename_missing_instrume(self):
+        """Test that missing INSTRUME raises ValueError."""
+        obj = RV2()
+        obj.headers["PRIMARY"] = OrderedDict()
+        obj.headers["PRIMARY"]["DATE-OBS"] = "2025-02-08T04:51:25"
+
+        with pytest.raises(ValueError, match="INSTRUME"):
+            obj.generate_standard_filename()
+
+    def test_generate_filename_missing_date_obs(self):
+        """Test that missing DATE-OBS raises ValueError."""
+        obj = RV2()
+        obj.headers["PRIMARY"] = OrderedDict()
+        obj.headers["PRIMARY"]["INSTRUME"] = "KPF"
+
+        with pytest.raises(ValueError, match="DATE-OBS"):
+            obj.generate_standard_filename()
+
+
+class TestValidateFilename:
+    """Test the validate_filename method."""
+
+    def test_validate_valid_filename(self):
+        """Test validation of a valid filename."""
+        obj = RV2()
+        assert obj.validate_filename("kpf_SL2_20250208T045125.fits")
+
+    def test_validate_invalid_filename(self):
+        """Test validation of an invalid filename."""
+        obj = RV2()
+        assert not obj.validate_filename("kpf_L2_standard.fits")
+
+    def test_validate_filename_with_path(self):
+        """Test validation strips directory path."""
+        obj = RV2()
+        assert obj.validate_filename("/some/path/kpf_SL2_20250208T045125.fits")
+        assert not obj.validate_filename("/some/path/kpf_L2_standard.fits")
+
+
+class TestCheckFilenameConvention:
+    """Test the check_filename_convention method."""
+
+    def test_check_valid_filename_no_warning(self):
+        """Test that valid filenames don't produce warnings."""
+        obj = RV2()
+        obj.headers["PRIMARY"] = OrderedDict()
+        obj.headers["PRIMARY"]["INSTRUME"] = "KPF"
+        obj.headers["PRIMARY"]["DATE-OBS"] = "2025-02-08T04:51:25"
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = obj.check_filename_convention("kpf_SL2_20250208T045125.fits")
+            assert result is True
+            assert len(w) == 0
+
+    def test_check_invalid_filename_warning(self):
+        """Test that invalid filenames produce warnings with suggestion."""
+        obj = RV2()
+        obj.headers["PRIMARY"] = OrderedDict()
+        obj.headers["PRIMARY"]["INSTRUME"] = "KPF"
+        obj.headers["PRIMARY"]["DATE-OBS"] = "2025-02-08T04:51:25"
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = obj.check_filename_convention("kpf_L2_standard.fits")
+            assert result is False
+            assert len(w) == 1
+            assert "does not follow the EPRV naming convention" in str(w[0].message)
+            assert "kpf_SL2_20250208T045125.fits" in str(w[0].message)
+
+    def test_check_invalid_filename_no_headers(self):
+        """Test warning when headers are missing for suggestion."""
+        obj = RV2()
+        # No PRIMARY header set
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = obj.check_filename_convention("bad_filename.fits")
+            assert result is False
+            assert len(w) == 1
+            assert "does not follow the EPRV naming convention" in str(w[0].message)


### PR DESCRIPTION
## Summary

Implements issue #142 to enforce the standard EPRV filename convention:

**`inst_SL#_YYYYMMDDThhmmss.fits`**

Where:
- `inst`: instrument name (lowercase, e.g., "kpf", "neid", "espresso")
- `SL#`: standard level ("SL2", "SL3", or "SL4")
- `YYYYMMDDThhmmss`: observation date/time from DATE-OBS header

## Changes

Added to `RVDataModel`:
- `FILENAME_PATTERN`: regex pattern for validating filenames
- `generate_standard_filename()`: generates compliant filename from INSTRUME and DATE-OBS headers
- `validate_filename()`: checks if a filename matches the convention
- `check_filename_convention()`: validates and issues warning with suggested filename if non-compliant

Updated `to_fits()`:
- Calls `check_filename_convention()` to warn about non-standard filenames
- Updates `FILENAME` header to match actual output filename

## Example

```python
from rvdata.instruments.kpf.level2 import KPFRV2

obj = KPFRV2.from_fits("native_kpf_file.fits", instrument="kpf")

# Get the suggested standard filename
standard_name = obj.generate_standard_filename()
# Returns: "kpf_SL2_20250208T045125.fits"

# Writing with non-standard name will warn
obj.to_fits("my_custom_name.fits")
# Warning: Filename 'my_custom_name.fits' does not follow the EPRV naming convention.
# Suggested filename: 'kpf_SL2_20250208T045125.fits'
```

## Test plan

- [x] Added 14 unit tests covering:
  - Valid and invalid filename pattern matching
  - Filename generation for L2, L3, L4 data
  - Handling of tuple-format headers (value, comment)
  - Error handling for missing headers
  - Warning generation with suggested filenames
- [x] All tests pass

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)