### PR TITLE
Fix echelle_order_to_order_index for Astropy Table inputs

### DIFF
--- a/rvdata/core/tools/stitch_spectrum.py
+++ b/rvdata/core/tools/stitch_spectrum.py
@@ -166,13 +166,13 @@ def bindensity_resampling_fixed(new_x, x, y, cov=None, kind="cubic"):
 
 def echelle_order_to_order_index(echelle_order, order_table):
     """
-    Convert echelle order number to order index using the order table DataFrame.
+    Convert echelle order number to order index using the order table.
     Parameters:
     -----------
     echelle_order : int
         The echelle order number to convert.
-    order_table : pandas.DataFrame
-        DataFrame containing 'ECHELLE_ORDER' and 'ORDER_INDEX' columns.
+    order_table : astropy.table.Table or pandas.DataFrame
+        Table containing 'ECHELLE_ORDER' and 'ORDER_INDEX' columns.
     Returns:
     --------
     int or None
@@ -180,10 +180,10 @@ def echelle_order_to_order_index(echelle_order, order_table):
     """
 
     try:
-        return order_table.loc[order_table["ECHELLE_ORDER"] == echelle_order][
-            "ORDER_INDEX"
-        ].values[0]
-    except IndexError:
+        mask = np.array(order_table["ECHELLE_ORDER"]) == echelle_order
+        matches = np.array(order_table["ORDER_INDEX"])[mask]
+        return int(matches[0])
+    except (IndexError, KeyError):
         return None
 
 

--- a/rvdata/tests/test_echelle_order_to_order_index.py
+++ b/rvdata/tests/test_echelle_order_to_order_index.py
@@ -1,6 +1,5 @@
 """Regression tests for echelle_order_to_order_index table-type compatibility."""
 
-import numpy as np
 import pandas as pd
 import pytest
 from astropy.table import Table

--- a/rvdata/tests/test_echelle_order_to_order_index.py
+++ b/rvdata/tests/test_echelle_order_to_order_index.py
@@ -1,0 +1,50 @@
+"""Regression tests for echelle_order_to_order_index table-type compatibility."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from astropy.table import Table
+
+from rvdata.core.tools.stitch_spectrum import echelle_order_to_order_index
+
+
+@pytest.fixture
+def rows():
+    return {
+        "ECHELLE_ORDER": [92, 93, 94, 95, 96],
+        "ORDER_INDEX": [0, 1, 2, 3, 4],
+    }
+
+
+@pytest.fixture(params=["dataframe", "astropy_table"])
+def order_table(request, rows):
+    if request.param == "dataframe":
+        return pd.DataFrame(rows)
+    return Table(rows)
+
+
+def test_returns_matching_order_index(order_table):
+    assert echelle_order_to_order_index(94, order_table) == 2
+
+
+def test_returns_int(order_table):
+    assert isinstance(echelle_order_to_order_index(92, order_table), int)
+
+
+def test_missing_echelle_order_returns_none(order_table):
+    assert echelle_order_to_order_index(999, order_table) is None
+
+
+def test_missing_column_returns_none(rows):
+    table = Table({"ECHELLE_ORDER": rows["ECHELLE_ORDER"]})
+    assert echelle_order_to_order_index(94, table) is None
+
+
+def test_astropy_table_without_indices_matches_dataframe(rows):
+    df = pd.DataFrame(rows)
+    table = Table(rows)
+    assert table.indices == []
+    for order in rows["ECHELLE_ORDER"]:
+        assert echelle_order_to_order_index(
+            order, table
+        ) == echelle_order_to_order_index(order, df)


### PR DESCRIPTION
## Summary
- Fixes #162: `echelle_order_to_order_index()` in `stitch_spectrum.py` used pandas-specific `.loc[]` indexing, which raised `"Can only use TableLoc for a table with indices"` when `ORDER_TABLE` was an `astropy.table.Table` (the form `from_fits` produces via the framework's `_read`).
- Replace `.loc[]` with a numpy-mask over column access, which is supported by both `pandas.DataFrame` and `astropy.table.Table`. Also broaden the `except` to include `KeyError` for missing columns.
- Fixes the failure path reported for MAROON-X L3 creation, and avoids needing per-instrument `.to_pandas()` coercion as a workaround.

## Test plan
- [ ] Build an L3 product for MAROON-X via `RV3.from_fits(l2_standard_file, instrument="MAROONX")` end-to-end without the `to_pandas()` workaround in `MAROONXRV3._read()`.
- [ ] Confirm KPF / NEID L3 stitching paths still produce identical outputs (pandas input path unchanged in behavior).
- [ ] Unit test: call `echelle_order_to_order_index` with both an `astropy.table.Table` and a `pandas.DataFrame` built from the same rows; verify equal results, and that a missing echelle order returns `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)