### PR TITLE
docs: register MAROON-X tutorial in Sphinx toctree (#101)

### DIFF
--- a/docs/source/_notebooks.rst
+++ b/docs/source/_notebooks.rst
@@ -7,4 +7,5 @@
 
    tutorials/DataStandard_Overview
    tutorials/KPF_Tutorial
+   tutorials/MAROONX_Tutorial
    tutorials/NEID_Tutorial

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -18,9 +18,18 @@ The :doc:`KPF Tutorial <tutorials/KPF_Tutorial>` provides a comprehensive guide 
 - **Level 3**: Creating stitched 1D spectra from L2, plotting spectral features
 - **Level 4**: Creating RV measurements from native KPF L2, analyzing velocities
 
+MAROON-X Tutorial
+-----------------
+
+The :doc:`MAROON-X Tutorial <tutorials/MAROONX_Tutorial>` provides a comprehensive guide to working with MAROON-X data at all levels:
+
+- **Level 2**: Creating L2 from native MAROON-X HDF5 files (separate blue and red cameras), examining echelle spectra and the order table
+- **Level 3**: Creating stitched 1D spectra from L2, plotting spectral features
+- **Level 4**: Creating RV measurements from MAROON-X L2 and SERVAL output, analyzing per-order velocities
+
 NEID Tutorial
 -------------
-    
+
 The :doc:`NEID Tutorial <tutorials/NEID_Tutorial>` provides a comprehensive guide to working with NEID data at all levels:
 
 - **Level 2**: Creating L2 from native NEID L2 file,access headers, examine extensions, plot spectra


### PR DESCRIPTION
## Summary

Registers the existing MAROON-X tutorial notebook into the Sphinx documentation so it actually renders in the published docs.

- Add `tutorials/MAROONX_Tutorial` to the hidden toctree in `docs/source/_notebooks.rst`
- Add a **MAROON-X Tutorial** section to `docs/source/tutorials.rst` (L2/L3/L4 creation + usage), mirroring the existing KPF and NEID entries

## Why

`docs/source/tutorials/MAROONX_Tutorial.ipynb` already exists with full L2/L3/L4 create + usage content (34 cells) but was not referenced in any toctree, so it never appeared in the built documentation. This unblocks the six "Docs include creation/usage example" items in #101.

With this merged, the only remaining MAROON-X v1.0 checklist item is optional Instrument Overview polish.

## Test plan

- [ ] Docs build / preview renders the **MAROON-X Tutorial** page and lists it under *Tutorials* (left to CI / docs preview — not built locally)

Refs #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
