### PR TITLE
ci: avoid duplicate fast-suite runs on main/develop pushes

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -1,7 +1,14 @@
 name: Fast CI - Code Style and Standard Regression Tests
 
+# CI split: ci-fast provides a quick signal on feature-branch pushes;
+# ci-full covers pull requests and the protected branches (main, develop).
+# main/develop are ignored here because ci-full already runs the same
+# codestyle and ubuntu/py3.13 test jobs on pushes to those branches.
 on:
   push:
+    branches-ignore:
+      - main
+      - develop
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
Fixes confirmed findings from the v0.4.0 release review on https://github.com/EPRV-RCN/RVData/pull/175.

### Changes

- Scoped the `push` trigger in `.github/workflows/ci-fast.yml` with `branches-ignore: [main, develop]`, so pushes to the protected branches no longer run ci-fast's codestyle and ubuntu/py3.13 test jobs, which are byte-identical to jobs in `ci-full.yml` (ci-full already triggers on push to main/develop). Per-workflow concurrency groups could not dedupe these duplicate runs.
- Added a comment block above the `on:` section in `ci-fast.yml` documenting the workflow split: ci-fast = quick signal on feature-branch pushes; ci-full = PRs + protected branches (main, develop).
- No job restructuring; only the trigger and comment were changed.
- Note: the remaining overlap — a push to a branch with an open PR triggers ci-fast on `push` and ci-full on `pull_request` — is the intentional fast-feedback path and is deliberately left in place.

### Review findings addressed

- https://github.com/EPRV-RCN/RVData/pull/175#issuecomment-4683138084 (ci-fast/ci-full duplicate jobs)

### Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-fast.yml'))"` — passed (YAML parses cleanly).
- `python3 -c "import rvdata; print(rvdata.__file__)"` — resolved inside the worktree, so no PYTHONPATH override was needed.
- `python3 -m pytest rvdata/tests --ignore=rvdata/tests/regression -q` — 55 passed, 6 warnings in 2.41s (matches the scout baseline of 55 passed / 6 benign warnings; zero failures, none pre-existing, none introduced). Networked regression tests were not run per instructions.

### Notes

Known minor review notes (non-blocking):

- Adding `branches-ignore` to a previously bare `on: push` trigger silently removes tag-push triggering: per GitHub Actions semantics, defining only `branches`/`branches-ignore` means the workflow no longer runs for tag pushes. The repo pushes release tags (v0.x), and neither ci-full (push filtered to main/develop branches) nor release-pypi (triggers on `release: published`) runs tests on tag pushes, so tag pushes now trigger no CI at all, whereas they previously ran ci-fast. Low impact since the tagged commit was already tested by ci-full on the branch push, and the change follows directly from the spec's prescribed fix, but the side effect is undocumented in the YAML comment and commit body. If tag-push CI is desired, add `tags: ["**"]` (or `tags-ignore: []`) alongside `branches-ignore`.
- Side effect of the spec-mandated fix: adding `branches-ignore` under `push` means tag pushes no longer trigger ci-fast (GitHub excludes tag events when only branch filters are defined on push). Previously bare `push:` matched tag pushes too, so a tag push now triggers no CI workflow at all (ci-full also filters to main/develop branches). Practical impact is nil — tags point at commits already tested on main/develop and PyPI publishing runs on `release: published` — but this behavior change is not mentioned in the YAML comment or commit message. Informational only; no action strictly required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
