### PR TITLE
fix: use exact speed of light for BARYCORR_Z conversion

### DIFF
--- a/rvdata/instruments/kpf/level2.py
+++ b/rvdata/instruments/kpf/level2.py
@@ -1,5 +1,6 @@
 from astropy.io import fits
 from astropy.table import Table
+from astropy import constants
 import numpy as np
 import pandas as pd
 import os
@@ -216,7 +217,7 @@ class KPFRV2(RV2):
         self.set_header("BARYCORR_KMS", OrderedDict(hdul1["BARY_CORR"].header))
         self.set_header("BARYCORR_Z", OrderedDict(hdul1["BARY_CORR"].header))
         self.set_data("BARYCORR_KMS", bary_kms)
-        self.set_data("BARYCORR_Z", bary_kms / 3e5)  # aproximate!!!
+        self.set_data("BARYCORR_Z", (bary_kms / constants.c.to("km/s")).value)
 
         self.create_extension(
             "EXPMETER",

--- a/rvdata/instruments/maroonx/level2.py
+++ b/rvdata/instruments/maroonx/level2.py
@@ -4,6 +4,7 @@
 import numpy as np
 import pandas as pd
 from astropy.io import fits
+from astropy.constants import c
 import os
 
 # import base class
@@ -228,8 +229,8 @@ class MAROONXRV2(RV2):
 
         berv_kms_b = float(header_blue['BERV_FLUXWEIGHTED_FRD'])/1000.0
         berv_kms_r = float(header_red['BERV_FLUXWEIGHTED_FRD'])/1000.0
-        berv_z_b = berv_kms_b / 3e5
-        berv_z_r = berv_kms_r / 3e5
+        berv_z_b = (berv_kms_b / c.to("km/s")).value
+        berv_z_r = (berv_kms_r / c.to("km/s")).value
         bjd_tdb_b = MXutils.compute_bjd_from_header(header_blue)
         bjd_tdb_r = MXutils.compute_bjd_from_header(header_red)
 


### PR DESCRIPTION
## Summary

MAROON-X and KPF computed the barycentric redshift `z = BERV / c` using the approximation `c = 3e5` km/s instead of the exact `299792.458` km/s. This introduces a **~6.9e-4 fractional error in z (~21 m/s for a 30 km/s BERV)** — well above the m/s precision the standard targets, and inconsistent with the exact `BARYCORR_KMS` written into the same products.

This switches both translators to `astropy.constants.c`, matching the convention already used by ESPRESSO/HARPS/NIRPS (and `core/tools/stitch_spectrum.py`).

### Changes
- `rvdata/instruments/maroonx/level2.py`: `berv_z_{b,r} = (berv_kms / c.to("km/s")).value`
- `rvdata/instruments/kpf/level2.py`: `BARYCORR_Z = (bary_kms / constants.c.to("km/s")).value`, and removed the `# aproximate!!!` marker. KPF imports the `constants` module (rather than `c`) to avoid colliding with the `c` loop variable in `createL2`.

### Verification
- `flake8` clean on both files.
- Numeric check at BERV = 30 km/s: old `3e5` value differs from the exact value by **20.75 m/s** (fractional `-6.9e-4`), confirming the reported magnitude.
- Regression tests (`test_maroonx`, `test_kpf`) assert filename conventions + level compliance; they do not pin `BARYCORR_Z` values, so no fixtures need regenerating.

Addresses the review finding on PR #175 (`maroonx/level2.py:232`, with the same fix applied to the KPF approximation flagged in that comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)