### PR TITLE
fix: copy L2 headers in L3 conversion to avoid mutating the input object

### DIFF
--- a/rvdata/core/models/level3.py
+++ b/rvdata/core/models/level3.py
@@ -202,8 +202,10 @@ class RV3(rvdata.core.models.base.RVDataModel):
             This method modifies the current RV3 object in place.
         """
 
-        # Set up the primary header
-        l3prihdr = l2obj.headers["PRIMARY"]
+        # Set up the primary header. Copy so that mutating the L3 header
+        # below does not corrupt the caller's L2 object (set_header stores
+        # the reference, it does not copy).
+        l3prihdr = l2obj.headers["PRIMARY"].copy()
         l3prihdr["DATALVL"] = "L3"
 
         # get the order table from level 2 data
@@ -342,8 +344,10 @@ class RV3(rvdata.core.models.base.RVDataModel):
         self.set_data("ORDER_TABLE", order_table)
         # set the headers into the level 3 object
         self.set_header("PRIMARY", l3prihdr)
-        self.set_header("INSTRUMENT_HEADER", l2obj.headers["INSTRUMENT_HEADER"])
-        self.set_header("ORDER_TABLE", l2obj.headers["ORDER_TABLE"])
+        # Copy so the L3 object does not share header objects with the
+        # caller's L2 object (set_header stores the reference, not a copy).
+        self.set_header("INSTRUMENT_HEADER", l2obj.headers["INSTRUMENT_HEADER"].copy())
+        self.set_header("ORDER_TABLE", l2obj.headers["ORDER_TABLE"].copy())
 
         # Inherit receipt from L2 object; @receipt_logged on this method
         # adds the conversion entry after this function returns.

--- a/rvdata/tests/regression/test_neid.py
+++ b/rvdata/tests/regression/test_neid.py
@@ -1,9 +1,11 @@
 import requests
 import os
+from astropy.io import fits
 from rvdata.core.models.base import RVDataModel
 from rvdata.core.models.level2 import RV2
 from rvdata.core.models.level3 import RV3
 from rvdata.core.models.level4 import RV4
+from rvdata.instruments.neid.level2 import NEIDRV2
 
 from rvdata.tests.regression.compliance import (
     check_l2_compliance, check_l3_compliance, check_l4_compliance,
@@ -60,6 +62,39 @@ def test_neid():
     assert os.path.basename(standard_l4_file).startswith("neid_SL4_"), \
         f"L4 filename should start with 'neid_SL4_', got '{os.path.basename(standard_l4_file)}'"
     check_l4_compliance(standard_l4_file)
+
+
+def test_l3_conversion_does_not_mutate_l2():
+    """convert_level2_to_level3 must not mutate the input L2 object.
+
+    Regression test for header aliasing: the L3 PRIMARY/INSTRUMENT_HEADER/
+    ORDER_TABLE headers were the same objects as the source L2's, so the
+    conversion flipped the caller's L2 to DATALVL='L3' and leaked stitching
+    keywords (e.g. BLZCORR) into it.
+    """
+    native_l2_file = download_files()
+
+    l2 = NEIDRV2()
+    l2.read(fits.open(native_l2_file), instrument="NEID")
+    datalvl_before = l2.headers["PRIMARY"].get("DATALVL")
+    keys_before = set(l2.headers["PRIMARY"].keys())
+
+    l3 = RV3()
+    l3.convert_level2_to_level3(l2)
+
+    # The source L2 object must be untouched by the conversion.
+    assert l2.headers["PRIMARY"].get("DATALVL") == datalvl_before
+    assert set(l2.headers["PRIMARY"].keys()) == keys_before
+    assert "BLZCORR" not in l2.headers["PRIMARY"]
+
+    # The L3 object must not share header objects with the source L2.
+    assert l2.headers["PRIMARY"] is not l3.headers["PRIMARY"]
+    assert (l2.headers["INSTRUMENT_HEADER"]
+            is not l3.headers["INSTRUMENT_HEADER"])
+    assert l2.headers["ORDER_TABLE"] is not l3.headers["ORDER_TABLE"]
+
+    # ...and the conversion still produced a Level 3 header.
+    assert l3.headers["PRIMARY"].get("DATALVL") == "L3"
 
 
 def test_neid_benchmark(benchmark):


### PR DESCRIPTION
## Summary

`RV3.convert_level2_to_level3` aliased the input L2 object's headers instead of copying them. `l3prihdr = l2obj.headers["PRIMARY"]` (no `.copy()`) was then mutated in place (`DATALVL="L3"`, `BLZCORR`, `INTERPMD`, …), and `set_header()` stores the reference rather than a copy. Net effect:

- After conversion the **caller's L2 object reports itself as L3** with stitching keywords — a later `l2.to_fits()` writes a corrupted L2 file.
- The `INSTRUMENT_HEADER` and `ORDER_TABLE` headers were likewise shared, so any later edit to an L3 header silently edits the L2's.

## Fix

Copy the three headers before mutating/storing them:
- `l3prihdr = l2obj.headers["PRIMARY"].copy()`
- `.copy()` on `INSTRUMENT_HEADER` and `ORDER_TABLE` headers when setting them into the L3 object.

## Verification

Reproduced on `develop` with a real NEID L2 object, before the fix:

```
L2 DATALVL after convert : L3      # was L2
same PRIMARY object?      True
L2 has BLZCORR now?       True
same INSTRUMENT_HEADER?   True
same ORDER_TABLE header?  True
```

After the fix, the L2 object is untouched (`DATALVL` stays `L2`, no `BLZCORR` leak, no shared header objects) and the L3 still converts correctly (`DATALVL="L3"`).

Adds `test_l3_conversion_does_not_mutate_l2` to `tests/regression/test_neid.py` (reuses the existing NEID fixture download) asserting the source L2 is unchanged and shares no header objects with the resulting L3. flake8 clean.

Addresses the review finding on PR #175 (`level3.py:206`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)