### PR TITLE
ci: auto-retry regression tests on transient network errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,11 @@ deps =
     pytest>=8.4.2
     pytest-benchmark[aspect]
     pytest-xdist
+    # Auto-retry tests that fail on transient network errors (regression
+    # tests download fixtures and remote astropy/SIMBAD data). See the
+    # --only-rerun pattern below for the exceptions this targets.
+    test: pytest-rerunfailures
+    coverage: pytest-rerunfailures
     coverage: pytest-cov
 
     # Oldest dependencies
@@ -43,11 +48,17 @@ pip_pre =
     predeps: true
     !predeps: false
 
+# Retry only failures whose traceback matches transient network errors,
+# so genuine test failures still fail fast. Patterns match the exception
+# type or message (e.g. URLError/TimeoutError from fixture and astropy
+# ephemeris/IERS downloads, DALServiceError from SIMBAD).
+rerun_opts = --reruns 3 --reruns-delay 10 --only-rerun "(URLError|TimeoutError|DALServiceError|ConnectionError|ConnectionResetError|RemoteDisconnected|ReadTimeout|Max retries|timed out|Connection failed)"
+
 commands =
     pip freeze
     benchmark: pytest --benchmark-only --pyargs rvdata {posargs}
-    test: pytest --benchmark-skip -v --pyargs rvdata {posargs}
-    coverage: pytest --cov=rvdata --cov-report=xml:{toxinidir}/coverage.xml --cov-report=term-missing --benchmark-skip -v --pyargs rvdata {posargs}
+    test: pytest --benchmark-skip -v {[testenv]rerun_opts} --pyargs rvdata {posargs}
+    coverage: pytest --cov=rvdata --cov-report=xml:{toxinidir}/coverage.xml --cov-report=term-missing --benchmark-skip -v {[testenv]rerun_opts} --pyargs rvdata {posargs}
 
 [testenv:codestyle]
 description = check code style with flake8


### PR DESCRIPTION
## Problem

The regression suite repeatedly fails CI on **transient network errors**, requiring a manual re-run each time. The downloads come from several sources:

- fixture servers (grinnell) → `URLError: <urlopen error timed out>`
- SIMBAD TAP queries → `pyvo.dal.exceptions.DALServiceError`
- remote astropy data — JPL ephemeris / IERS (e.g. `test_espresso`'s moon-sun barycentric calc does `SPK.open(download_file(...))`) → `URLError`/`TimeoutError`

These are all flakes, not real failures — a plain re-run goes green.

## Fix

Add `pytest-rerunfailures` and pass:

```
--reruns 3 --reruns-delay 10 --only-rerun "(URLError|TimeoutError|DALServiceError|ConnectionError|ConnectionResetError|RemoteDisconnected|ReadTimeout|Max retries|timed out|Connection failed)"
```

so a failing test is retried (up to 3×, 10 s apart) **only** when its traceback matches a transient network error. Genuine failures (assertions, logic errors) still fail immediately. Applied to the `test` and `coverage` envs; `benchmark` is left untouched.

## Verification

- `tox c` parses the config correctly (substitution expands, regex stays a single quoted arg); `pytest-rerunfailures` lands in the `test`/`coverage` deps and not in `benchmark`.
- Local simulation with the exact flags: a test raising `URLError("timed out")` was reran twice then passed, while an `assert 1 == 2` failed immediately with no rerun.

```
test_demo.py::test_network_flaky RERUN
test_demo.py::test_network_flaky RERUN
test_demo.py::test_network_flaky PASSED
test_demo.py::test_real_failure FAILED
1 failed, 1 passed, 2 rerun
```

This targets the exact "usual ephemeral thing" we keep re-triggering by hand. A complementary follow-up (not in this PR) could cache `~/.astropy/cache` across runs so the ephemeris/IERS data downloads once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)