### PR TITLE
Fix silent loss of PRIMARY header comments on round-trip

### DIFF
--- a/rvdata/core/models/base.py
+++ b/rvdata/core/models/base.py
@@ -304,10 +304,18 @@ class RVDataModel(object):
             [LEVEL2_PRIMARY_KEYWORDS, LEVEL3_PRIMARY_KEYWORDS, LEVEL4_PRIMARY_KEYWORDS]
         ).iterrows():
             key = row["Keyword"]
-            if key in self.headers["PRIMARY"]:
-                value = self.headers["PRIMARY"][key]
+            header = self.headers["PRIMARY"]
+            if key in header:
+                # A fits.Header keeps the comment in a parallel store, so
+                # indexing returns only the scalar. Pass the comment through
+                # as a (value, comment) tuple so the recast preserves it
+                # rather than overwriting it with an empty string.
+                if isinstance(header, fits.Header):
+                    value = (header[key], header.comments[key])
+                else:
+                    value = header[key]
                 parsed_value = parse_value_to_datatype(key, row["DataType"], value)
-                self.headers["PRIMARY"][key] = parsed_value
+                header[key] = parsed_value
 
     def to_fits(self, out_filedir=None, out_filename=None):
         """
@@ -730,9 +738,18 @@ class RVDataModel(object):
         for key, value in hdu_definitions:
             hduname = key
             if value == "PrimaryHDU":
-                head = fits.Header()
-                for keyword, content in self.headers[key].items():
-                    head[keyword] = content
+                # Preserve comments regardless of the in-memory header form.
+                # A fits.Header (e.g. set by from_fits) keeps comments in a
+                # parallel store, so iterating .items() would yield bare
+                # scalars and silently drop them; copy it directly instead.
+                # A plain dict holds (value, comment) tuples, which the
+                # element-wise assignment expands correctly.
+                if isinstance(self.headers[key], fits.Header):
+                    head = self.headers[key].copy()
+                else:
+                    head = fits.Header()
+                    for keyword, content in self.headers[key].items():
+                        head[keyword] = content
                 hdu = fits.PrimaryHDU(header=head)
                 hdu_list.insert(0, hdu)
             elif value == "ImageHDU":

--- a/rvdata/tests/test_base_serialization.py
+++ b/rvdata/tests/test_base_serialization.py
@@ -1,0 +1,51 @@
+# Tests for RVDataModel header serialization (core.models.base)
+from collections import OrderedDict
+
+from astropy.io import fits
+
+from rvdata.core.models.level2 import RV2
+
+
+def _write_minimal_l2(path):
+    """Write a minimal standard-format L2 file whose PRIMARY header carries
+    comments on both a standard keyword (recast on read) and a non-standard one."""
+    primary = fits.PrimaryHDU()
+    primary.header["INSTRUME"] = ("KPF", "Instrument name")  # standard keyword
+    primary.header["EXPTIME"] = (60.0, "[s] Exposure time")  # standard keyword
+    primary.header["MYNOTE"] = ("hi", "a non-standard note")  # not recast
+    fits.HDUList([primary]).writeto(path, overwrite=True)
+
+
+def test_roundtrip_preserves_primary_comments(tmp_path):
+    """from_fits -> to_fits must not drop PRIMARY header comments.
+
+    Regression: from_fits stores PRIMARY as an astropy fits.Header (comments in
+    a parallel store). Two sites silently dropped those comments on round-trip:
+    the read-path keyword recast overwrote them with "", and _create_hdul
+    rebuilt PRIMARY from bare scalars. Comments like the [s]/[km/s] unit
+    annotations vanished from the written file.
+    """
+    src = tmp_path / "min_L2.fits"
+    _write_minimal_l2(src)
+
+    model = RV2.from_fits(str(src))
+    model.to_fits(out_filedir=str(tmp_path), out_filename="roundtrip.fits")
+
+    written = fits.open(tmp_path / "roundtrip.fits")[0].header
+    assert written.comments["INSTRUME"] == "Instrument name"
+    assert written.comments["EXPTIME"] == "[s] Exposure time"
+    assert written.comments["MYNOTE"] == "a non-standard note"
+
+
+def test_create_hdul_preserves_primary_comments_from_ordereddict():
+    """The translator-built form (OrderedDict of (value, comment) tuples) must
+    keep working and retain comments through _create_hdul."""
+    model = RV2()
+    primary = OrderedDict()
+    primary["INSTRUME"] = ("KPF", "Instrument name")
+    primary["EXPTIME"] = (60.0, "[s] Exposure time")
+    model.headers["PRIMARY"] = primary
+
+    written = next(h for h in model._create_hdul() if h.name == "PRIMARY").header
+    assert written.comments["INSTRUME"] == "Instrument name"
+    assert written.comments["EXPTIME"] == "[s] Exposure time"


### PR DESCRIPTION
## Summary

A `from_fits` → `to_fits` round-trip of a standard-format file silently strips nearly every comment from the PRIMARY header — including the `[s]` / `[km/s]` EPRV unit annotations. On `base_L2_standard.fits`, PRIMARY goes from **43 commented cards to 3** (only the structural `SIMPLE`/`BITPIX`/`NAXIS` that astropy regenerates survive). Non-PRIMARY extensions are unaffected.

This surfaced from an audit by Greg Gilbert while standardizing header keyword access. Note: the audit described it as affecting "all extensions other than PRIMARY" — the reproduction shows the opposite, it is **PRIMARY-only**.

## Root cause

`from_fits` stores the PRIMARY header as an astropy `fits.Header`, which keeps comments in a parallel store rather than inline as `(value, comment)` tuples. Two sites assumed the tuple-dict form and dropped comments when handed a `fits.Header`:

1. **Read-path keyword recast** (`base.py`, in `read`): `value = self.headers["PRIMARY"][key]` returns a bare scalar from a `fits.Header`, so `parse_value_to_datatype` returns `(value, "")` and the write-back overwrites the comment with an empty string — for every standard keyword.
2. **`_create_hdul`**: rebuilt PRIMARY via `for k, v in header.items()`, which yields bare scalars for a `fits.Header`, discarding comments entirely.

## Fix

Both sites now detect a `fits.Header` and preserve its comments (passing `(value, comment)` through the recast; copying the header directly in `_create_hdul`). The existing `OrderedDict`-of-tuples path produced by instrument translators is unchanged.

After the fix, `base_L2_standard.fits` round-trips 43 → 43 and is stable across repeated round-trips; KPF/NEID/ESPRESSO L2–L4 standard files all preserve their comments.

## Testing

- New `rvdata/tests/test_base_serialization.py`: an end-to-end `from_fits`→`to_fits` round-trip asserting comments on a standard keyword (recast site) and a non-standard keyword survive, plus a `_create_hdul` test for the translator-built `OrderedDict` form. Verified the round-trip test fails on the pre-fix code and passes after.
- Full non-regression suite: 57 passed.

## Note on target branch

Opened against **`develop`**, where the bug lives (`_create_hdul` is in `base.py` with the `.items()` loop). `main` is currently behind `develop` and carries a differently-refactored `_create_hdul` (per-level methods already using `fits.Header(...)`) that does **not** have this bug — so this fix targets the active development line ahead of the standard release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)