### PR TITLE
fix: receipt logging crashes outside a git checkout (#181)

### DIFF
--- a/rvdata/core/models/base.py
+++ b/rvdata/core/models/base.py
@@ -519,8 +519,11 @@ class RVDataModel(object):
         time = datetime.datetime.now().isoformat()
 
         # get version control info (git)
-        repo = git.Repo(search_parent_directories=True)
         try:
+            # git.Repo() must be inside the try: it raises InvalidGitRepositoryError
+            # when run outside a checkout (e.g. a pip-installed package), which the
+            # except clause below is meant to handle by falling back to package metadata.
+            repo = git.Repo(search_parent_directories=True)
             git_commit_hash = repo.head.object.hexsha
             git_branch = repo.active_branch.name
             git_tag = str(repo.tags[-1])

--- a/rvdata/tests/test_receipt.py
+++ b/rvdata/tests/test_receipt.py
@@ -17,6 +17,7 @@ Also covers the ``@receipt_logged`` decorator introduced in PR #170:
 
 import os
 import tempfile
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -44,6 +45,35 @@ def test_receipt_add_entry_uses_csv_column_names():
     assert row["FUNCTION"] == "foo"
     assert row["ARGS"] == "bar=1"
     assert row["STATUS"] == "PASS"
+
+
+def test_receipt_add_entry_survives_without_git_repo():
+    """Regression for EPRV-RCN/RVData#181.
+
+    A pip-installed package run outside any git checkout makes
+    ``git.Repo(search_parent_directories=True)`` raise
+    InvalidGitRepositoryError. That call must sit inside the try block so the
+    except clause can fall back to package metadata; previously it was one line
+    above the try, so the error escaped and crashed every ``from_fits`` call.
+    """
+    from rvdata.core.models import base
+    from git.exc import InvalidGitRepositoryError
+
+    def _no_repo(*args, **kwargs):
+        raise InvalidGitRepositoryError("simulated pip-installed, no git checkout")
+
+    with mock.patch.object(base.git, "Repo", _no_repo):
+        rv2 = RV2()
+        # Must not raise; should fall back to importlib package metadata.
+        rv2.receipt_add_entry("from_fits", "", "PASS")
+
+    row = rv2.receipt.iloc[-1]
+    assert row["FUNCTION"] == "from_fits"
+    assert row["STATUS"] == "PASS"
+    # Fallback populates version fields from package metadata (string-typed,
+    # never raising); they exist as strings rather than the git values.
+    for col in ("CODE_RELEASE", "BRANCH_NAME", "COMMIT_HASH"):
+        assert isinstance(row[col], str)
 
 
 def test_receipt_extension_empty_columns_are_string_typed():


### PR DESCRIPTION
Fixes #181.

## Problem
A fresh `pip install rv-data-standard` followed by `RV2.from_fits(...)` crashes for every user who isn't sitting inside a git checkout:

```
InvalidGitRepositoryError: /Users/jenburt/Desktop/EPRV_DF_Paper
```

This makes the published package unusable as installed — the failure happens on the very first `from_fits` call in the tutorials.

## Root cause
In `receipt_add_entry`, the version-control lookup was structured like this:

```python
repo = git.Repo(search_parent_directories=True)   # outside the try
try:
    git_commit_hash = repo.head.object.hexsha
    ...
except (TypeError, IndexError, InvalidGitRepositoryError):
    # fall back to package metadata for pip-installed / no-checkout use
```

The `except` clause was written specifically to handle `InvalidGitRepositoryError` for "testing env or pip-installed package", but the call that *raises* it — `git.Repo(...)` — sat one line **above** the `try`, so the exception escaped uncaught.

## Fix
Move the `git.Repo(...)` call inside the `try` block so the existing fallback to package metadata (`importlib.metadata.version`) runs as intended. One-line scope fix; no behavior change inside a real checkout.

## Verification
- Reproduced the crash in a non-git directory, confirmed it's gone after the fix (receipt now populated from package metadata: `CODE_RELEASE`/`BRANCH_NAME`/`COMMIT_HASH`).
- Added `test_receipt_add_entry_survives_without_git_repo`, which patches `git.Repo` to raise `InvalidGitRepositoryError` and asserts the entry is still recorded. This fails on the old code and passes on the new.
- Full `test_receipt.py` suite (10 tests) passes; flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)