### PR TITLE
docs: explain EPRVTAG and VOCLASS PRIMARY header keywords

### DIFF
--- a/docs/source/primaryheader.rst
+++ b/docs/source/primaryheader.rst
@@ -44,10 +44,20 @@ PRIMARY Header Keywords
 **MULTIPLICITY** : Keyword in the PRIMARY extension that indicates whether or not an extension can be duplicated to have
 multiple HDUs based on, e.g., the number of traces.
 
-**REQUIRED** : Keyword in the PRIMARY extension that indicates whether or not an extension must be present and 
+**REQUIRED** : Keyword in the PRIMARY extension that indicates whether or not an extension must be present and
 meaningfully populated in the FITS file in order for the file to be compliant with the EPRV Data Standard.
 
-**INSTERA** : Tag for the "instrument era" used to track permanent changes to instrument (e.g., 1.1.2). Major changes 
+**EPRVTAG** : Version of the EPRV Data Standard that the file conforms to, given as the bare semantic version of the
+standard (e.g., ``v1.1.0``). Required in every compliant file so that consumers know which revision of the standard
+the file was written against.
+
+**VOCLASS** : The same EPRV Data Standard version as **EPRVTAG**, expressed as a Virtual Observatory (VO) *class*
+string — the standard's name followed by its version (e.g., ``EPRVSTANDARDv1.1.0``). This follows the IVOA / Virtual
+Observatory convention in which ``VOCLASS`` declares a data product's class and version, allowing VO-aware archives
+and tooling to identify a file as an EPRV Data Standard product. It carries the same version information as
+**EPRVTAG**, just in a VO-discoverable form.
+
+**INSTERA** : Tag for the "instrument era" used to track permanent changes to instrument (e.g., 1.1.2). Major changes
 that result in RV offset are recorded in the first numeral space. Small but permanent changes, (changes in the calibration 
 light sources, etc) that don't necessarily introduce RV offsets but do represent an ongoing status change in the instrument, 
 are recorded in the second numeral. Anything that could impact the calibration or science outputs goes here. Even smaller 


### PR DESCRIPTION
## What
Adds prose documentation for the **`EPRVTAG`** and **`VOCLASS`** PRIMARY-header keywords to `docs/source/primaryheader.rst`, in the "PRIMARY Header Keywords" notable-keywords section (same style as the existing `INSTERA` / `MULTIPLICITY` / `REQUIRED` entries).

## Why
Both keywords already appear in the auto-rendered keyword table (from `L2-PRIMARY-keywords.csv`), but each carries the identical, terse description *"Version of EPRV standard applied."* That doesn't explain how they differ or why there are two of them — a reader can't tell `EPRVTAG` from `VOCLASS` from the table alone.

## The distinction now documented
- **`EPRVTAG`** — the standard version as a bare semantic version (e.g. `v1.1.0`).
- **`VOCLASS`** — the same version expressed as a Virtual Observatory *class* string (e.g. `EPRVSTANDARDv1.1.0`), following the IVOA / VO convention where `VOCLASS` declares a data product's class + version so VO-aware archives and tooling can identify an EPRV Data Standard file.

## Notes
- Docs-only change; no code or schema touched.
- Verified the reStructuredText parses cleanly (docutils, no warnings).

### Possible follow-ups (not in this PR)
- The two `Description` cells in `L2-PRIMARY-keywords.csv` are identical (`"Version of EPRV standard applied"`); could be differentiated at the schema level, but that changes the machine-readable standard, so left for the change-control process.
- The example values in the schema are `v1.1.0` while the released standard is `v0.4.0` — worth confirming translators stamp the *current* standard version into these keywords rather than a hardcoded value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)