### PR TITLE
ci: cache the JPL DE430 ephemeris across test jobs

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -66,7 +66,9 @@ jobs:
       - name: Restore astropy data cache
         uses: actions/cache/restore@v4
         with:
-          path: ~/.astropy
+          path: |
+            ~/.astropy/cache
+            ~/.cache/astropy
           key: astropy-${{ runner.os }}-de430-${{ env.ASTROPY_CACHE_VERSION }}
 
       - name: Install dependencies

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -21,6 +21,9 @@ permissions:
 
 env:
   PIP_CACHE_DIR: ~/.cache/pip
+  # Must match ci-full.yml, which is what populates this cache. develop is the
+  # default branch, so caches it writes are readable from every branch here.
+  ASTROPY_CACHE_VERSION: v1
 
 jobs:
   codestyle:
@@ -57,6 +60,14 @@ jobs:
         with:
           python-version: '3.13'
           cache: 'pip'
+
+      # Read-only: ci-full is the only writer. A miss here just means the JPL
+      # ephemeris is downloaded as before.
+      - name: Restore astropy data cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.astropy
+          key: astropy-${{ runner.os }}-de430-${{ env.ASTROPY_CACHE_VERSION }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -69,7 +69,9 @@ jobs:
         id: astropy-cache
         uses: actions/cache@v4
         with:
-          path: ~/.astropy
+          path: |
+            ~/.astropy/cache
+            ~/.cache/astropy
           key: astropy-${{ runner.os }}-de430-${{ env.ASTROPY_CACHE_VERSION }}
 
       # A cold-cache outage at naif.jpl.nasa.gov must not block the 29 jobs
@@ -84,16 +86,44 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install astropy jplephem
           python - <<'PY'
+          import os
+          import shutil
+
+          from astropy.config.paths import get_cache_dir
           from astropy.coordinates import (
               get_body_barycentric_posvel,
               solar_system_ephemeris,
           )
           from astropy.time import Time
+          from astropy.utils.data import is_url_in_cache
 
-          # Downloads de430.bsp from naif.jpl.nasa.gov (~114 MB) plus the IERS
-          # Earth-orientation tables, all into ~/.astropy/cache.
-          with solar_system_ephemeris.set('jpl'):
-              get_body_barycentric_posvel('moon', Time(2458000.0, format='jd'))
+          DE430 = (
+              "https://naif.jpl.nasa.gov/pub/naif/generic_kernels"
+              "/spk/planets/de430.bsp"
+          )
+
+          # Pulls de430.bsp (~114 MB) plus the IERS Earth-orientation tables.
+          with solar_system_ephemeris.set("jpl"):
+              get_body_barycentric_posvel("moon", Time(2458000.0, format="jd"))
+
+          # Fail loudly rather than saving an empty cache: a step that silently
+          # downloads nothing looks identical to a successful one.
+          assert is_url_in_cache(DE430), "de430.bsp did not reach the cache"
+
+          # astropy <8 caches in ~/.astropy/cache; astropy >=8 moved to
+          # ~/.cache/astropy. The tox matrix spans both (olddeps pins
+          # astropy 7.2), and the on-disk layout under either root is
+          # identical, so mirror into both and let each env find its own.
+          src = get_cache_dir()
+          home = os.path.expanduser("~")
+          print(f"astropy cache={src!r} home={home!r}")
+          for dest in (
+              os.path.join(home, ".astropy", "cache"),
+              os.path.join(home, ".cache", "astropy"),
+          ):
+              if os.path.normpath(dest) != os.path.normpath(src):
+                  shutil.copytree(src, dest, dirs_exist_ok=True)
+                  print(f"mirrored -> {dest}")
           PY
 
   regression:
@@ -119,7 +149,9 @@ jobs:
       - name: Restore astropy data cache
         uses: actions/cache/restore@v4
         with:
-          path: ~/.astropy
+          path: |
+            ~/.astropy/cache
+            ~/.cache/astropy
           key: astropy-${{ runner.os }}-de430-${{ env.ASTROPY_CACHE_VERSION }}
 
       - name: Install dependencies
@@ -147,7 +179,9 @@ jobs:
       - name: Restore astropy data cache
         uses: actions/cache/restore@v4
         with:
-          path: ~/.astropy
+          path: |
+            ~/.astropy/cache
+            ~/.cache/astropy
           key: astropy-${{ runner.os }}-de430-${{ env.ASTROPY_CACHE_VERSION }}
 
       - name: Install dependencies
@@ -188,7 +222,9 @@ jobs:
       - name: Restore astropy data cache
         uses: actions/cache/restore@v4
         with:
-          path: ~/.astropy
+          path: |
+            ~/.astropy/cache
+            ~/.cache/astropy
           key: astropy-${{ runner.os }}-de430-${{ env.ASTROPY_CACHE_VERSION }}
 
       - name: Install dependencies

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -18,6 +18,9 @@ permissions:
 
 env:
   PIP_CACHE_DIR: ~/.cache/pip
+  # Bump to force a rebuild of the astropy download cache (DE430 is immutable,
+  # so under normal circumstances this never needs to change).
+  ASTROPY_CACHE_VERSION: v1
 
 jobs:
   codestyle:
@@ -41,10 +44,60 @@ jobs:
       - name: Run flake8 checks
         run: tox -e codestyle
 
+  # Populate the astropy download cache once per OS so the test matrix does not
+  # re-fetch the 114 MB JPL DE430 kernel in every job. This job is the only
+  # writer; every consumer restores read-only via actions/cache/restore, which
+  # has no post-job save step and so cannot race for the key.
+  ephemeris:
+    name: Warm ephemeris cache (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: codestyle
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Cache astropy data
+        id: astropy-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.astropy
+          key: astropy-${{ runner.os }}-de430-${{ env.ASTROPY_CACHE_VERSION }}
+
+      # A cold-cache outage at naif.jpl.nasa.gov must not block the 29 jobs
+      # downstream -- without continue-on-error it would turn one flaky
+      # download into a hard failure for the whole matrix. Failing here just
+      # leaves the caches empty, which is the pre-cache behaviour.
+      - name: Populate astropy cache
+        if: steps.astropy-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install astropy jplephem
+          python - <<'PY'
+          from astropy.coordinates import (
+              get_body_barycentric_posvel,
+              solar_system_ephemeris,
+          )
+          from astropy.time import Time
+
+          # Downloads de430.bsp from naif.jpl.nasa.gov (~114 MB) plus the IERS
+          # Earth-orientation tables, all into ~/.astropy/cache.
+          with solar_system_ephemeris.set('jpl'):
+              get_body_barycentric_posvel('moon', Time(2458000.0, format='jd'))
+          PY
+
   regression:
     name: Regression Tests - Python 3.${{ matrix.python-ver }} (${{ matrix.tox-env }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    needs: codestyle
+    needs: [codestyle, ephemeris]
     strategy:
       fail-fast: false
       matrix:
@@ -61,6 +114,12 @@ jobs:
           python-version: '3.${{ matrix.python-ver }}'
           cache: 'pip'
 
+      - name: Restore astropy data cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.astropy
+          key: astropy-${{ runner.os }}-de430-${{ env.ASTROPY_CACHE_VERSION }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -72,7 +131,7 @@ jobs:
   coverage:
     name: Coverage Report
     runs-on: ubuntu-latest
-    needs: codestyle
+    needs: [codestyle, ephemeris]
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -82,6 +141,12 @@ jobs:
         with:
           python-version: '3.13'
           cache: 'pip'
+
+      - name: Restore astropy data cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.astropy
+          key: astropy-${{ runner.os }}-de430-${{ env.ASTROPY_CACHE_VERSION }}
 
       - name: Install dependencies
         run: |
@@ -117,6 +182,12 @@ jobs:
         with:
           python-version: '3.${{ matrix.python-ver }}'
           cache: 'pip'
+
+      - name: Restore astropy data cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.astropy
+          key: astropy-${{ runner.os }}-de430-${{ env.ASTROPY_CACHE_VERSION }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -57,11 +57,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      # No checkout and no pip cache on purpose: this job only needs astropy
+      # and jplephem to drive the download, not the project itself. (setup-
+      # python's pip cache requires a checked-out pyproject.toml to hash.)
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-          cache: 'pip'
 
       - name: Cache astropy data
         id: astropy-cache


### PR DESCRIPTION
## Problem

The ESPRESSO translator calls `solar_system_ephemeris.set('jpl')` (`rvdata/instruments/espresso/utils/create_PRIMARY.py:821`), making astropy fetch the **114 MB** DE430 kernel from `naif.jpl.nasa.gov`. HARPS, HARPS-N and NIRPS call the same ephemeris, so this widens as those translators come online.

Nothing in CI persisted the astropy cache. With 3 OS × 3 Python × 3 tox-env = 27 regression jobs plus coverage and benchmark, that was **29 cold fetches of a 114 MB file per push** — about 3.3 GB from one NASA host inside a four-minute window.

The symptom:

```
FAILED rvdata/tests/regression/test_espresso.py::test_espresso
       - urllib.error.URLError: <urlopen error timed out>
== 1 failed, 65 passed, 4 skipped, 18 warnings, 3 rerun ==
```

Always `test_espresso`, always with 65 tests passing beside it, and `3 rerun` showing the existing `--reruns 3` was **exhausted**. It went red on four consecutive attempts and is holding up the v1.0.0 release (#202).

## Approach: one writer, many readers

Dropping `actions/cache` into the regression job would give 29 jobs racing one key: 28 get *"unable to reserve cache"*, and on a cold cache **every one still downloads**, because none can restore what does not exist yet.

Instead a new `ephemeris` job, matrixed over the three runner OSes, populates the cache once and is the **sole writer**. The 29 consumers use `actions/cache/restore`, which has no post-job save step and so cannot contend for the key.

```
codestyle → ephemeris (×3 OS, writes) → regression (×27, read-only)
                                      → coverage        (read-only)
                                      → benchmark       (read-only)
```

## Two cache roots, not one

The non-obvious part. **Astropy 8 relocated its cache**, and the tox matrix straddles the change — `test-olddeps` pins `astropy==7.2.*` while `test` and `test-predeps` resolve to 8.x:

| astropy | cache directory |
|---|---|
| 7.2.2 | `$HOME/.astropy/cache` |
| 8.0.1 | `$HOME/.cache/astropy` |

Neither root alone is sufficient, so both are cached. The on-disk layout under either root is identical — same url-hash directory names, same `contents`/`url` files — so the warm-up downloads **once** and mirrors the tree into the other location rather than installing two astropy versions and downloading twice.

Setting `XDG_CACHE_HOME` would collapse this to a single path (both versions honour it, verified), but it needs the directory pre-created for astropy 7 plus an addition to `tox.ini` `passenv`. Caching two paths is the smaller change. The cost is that each cache stores the tree twice — **216 MiB per OS**, 648 MiB total against a 10 GB repo budget. Worth revisiting if that ever matters.

## Other design notes

- **Keyed on `runner.os`.** GitHub scopes caches by key alone, not platform, so an unkeyed cache could restore Linux paths onto Windows.
- **`continue-on-error` on the populate step.** Without it, a NASA outage on a cold cache converts one flaky download into a hard block on all 29 downstream jobs. With it, the worst case is exactly today's behaviour.
- **An explicit `assert is_url_in_cache(de430)`.** During development the step passed while caching nothing — a silent no-op is indistinguishable from success, which is the one failure mode a cache warm-up must not have. It now fails visibly while still not blocking.
- **`ASTROPY_CACHE_VERSION: v1`** is a manual bump handle. DE430 is immutable, so the cache is written roughly once and hit indefinitely; constant reads mean the 7-day idle eviction never fires. (`runner.os` is unavailable in workflow-level `env`, hence only the version suffix lives there.)
- **No `tox.ini` change required.** Tests run under `changedir = .tmp/{envname}`, so the cache is only reachable if `expanduser("~")` resolves inside the tox env. It does: tox 4's default `passenv` carries `HOME` on POSIX and `USERPROFILE` on Windows.
- **`ci-fast` gets the read-only restore too.** `develop` is the repo default branch, so caches written there are readable from every branch and PR.

## Verification

**37/37 checks green**, including the full 27-job regression matrix.

From the warm-up job log — cold cache, download, mirror, save:

```
Cache not found for input keys: astropy-Linux-de430-v1
astropy cache='/home/runner/.cache/astropy' home='/home/runner'
mirrored -> /home/runner/.astropy/cache
Cache saved with key: astropy-Linux-de430-v1
```

From a **`test-olddeps`** consumer — i.e. `astropy==7.2.2`, which reads the *mirrored* root, so this is what proves the mirror works and not merely that the download happened:

```
Cache hit for: astropy-Linux-de430-v1
Cache restored successfully
astropy==7.2.2
test_espresso.py::test_espresso PASSED
```

Warm-up cost, including the 114 MB download on a cold cache: **18 s** (ubuntu), 23 s (macOS), 42 s (Windows).

Also checked before pushing:
- Enumerated a populated `~/.astropy` to establish the exact URLs and the 114 MB figure.
- Read tox 4's `_default_pass_env` source to confirm `HOME`/`USERPROFILE` pass through without a `tox.ini` edit.
- Installed astropy 7.2.2 and 8.0.1 side by side to pin down each cache root, and confirmed a mirrored tree is recognised by **both** via `is_url_in_cache`.
- Extracted the embedded populate script back out of the YAML, then compiled it, ran flake8 over it, and executed it against a fake `$HOME` with the download stubbed.
- Parsed both workflows with `yaml.safe_load` and asserted every cache entry uses an identical key template.

## Scope

`--reruns 3` stays as the backstop for SIMBAD and the IERS hosts. One thing to watch: `finals2000A.all` does change, and astropy re-downloads it once `iers.conf.auto_max_age` (30 days) lapses — so roughly monthly one job takes a 3.5 MB hit. Small, and from a host that has not been failing. Disabling IERS auto-download is possible since all fixtures are past dates covered by astropy's bundled IERS-B, but that changes test behaviour and does not belong in a CI fix.

Note the three caches above currently sit on `refs/pull/203/merge`. Once this lands, the first push run on `develop` rewrites them there; since `develop` is the default branch, they then become readable from every branch and PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
